### PR TITLE
Cleans up the mapping code

### DIFF
--- a/examples/alu/isa.py
+++ b/examples/alu/isa.py
@@ -10,6 +10,8 @@ class ALUOP(Enum):
     Or =  new_instruction()
     And = new_instruction()
     XOr = new_instruction()
+    Neg = new_instruction()
+    Not = new_instruction()
 
 class Inst(Product):
     alu_op = ALUOP

--- a/examples/alu/sim.py
+++ b/examples/alu/sim.py
@@ -3,26 +3,33 @@ import typing as  tp
 from .isa import *
 from hwtypes import TypeFamily
 
-def gen_alu(family : TypeFamily, width=16):
-    Data = family.BitVector[16]
-    def alu(op : ALUOP, a : Data, b : Data):
-        if op == ALUOP.Add:
-            res = a + b
-        elif op == ALUOP.Sub:
-            res = a-b
-        elif op == ALUOP.And:
-            res = a & b
-        elif op == ALUOP.Or:
-            res = a | b
-        elif op == ALUOP.XOr:
-            res = a ^ b
-        else:
-            raise PeakNotImplementedError(op)
-        return res
+def gen_ALU(width=16):
+    def family_closure(family):
+        Data = family.BitVector[width]
+        def alu(op : ALUOP, a : Data, b : Data):
+            if op == ALUOP.Neg:
+                a = Data(0)
+            elif op == ALUOP.Not:
+                a = Data(-1)
 
-    class ALU(Peak):
+            if op == ALUOP.Add:
+                res = a + b
+            elif (op == ALUOP.Sub) | (op == ALUOP.Neg):
+                res = a-b
+            elif op == ALUOP.And:
+                res = a & b
+            elif op == ALUOP.Or:
+                res = a | b
+            elif (op == ALUOP.XOr) | (op == ALUOP.Not):
+                res = a ^ b
+            else:
+                raise PeakNotImplementedError(op)
+            return res
 
-        @name_outputs(alu_res=Data)
-        def __call__(self,inst : Inst, a : Data, b : Data):
-            return alu(inst.alu_op,a,b)
-    return ALU
+        class ALU(Peak):
+
+            @name_outputs(alu_res=Data)
+            def __call__(self,inst : Inst, a : Data, b : Data):
+                return alu(inst.alu_op,a,b)
+        return ALU
+    return family_closure

--- a/examples/smallir/__init__.py
+++ b/examples/smallir/__init__.py
@@ -1,0 +1,1 @@
+from .ir import *

--- a/examples/smallir/ir.py
+++ b/examples/smallir/ir.py
@@ -1,0 +1,42 @@
+from peak.ir import IR
+from peak import Peak, name_outputs
+from hwtypes import BitVector
+from hwtypes.adt import Enum
+
+def gen_SmallIR(width):
+    SmallIR = IR()
+    def add_binary(name,fun):
+        def family_closure(family):
+            Data = family.BitVector[width]
+            class Binary(Peak):
+                @name_outputs(out=Data)
+                def __call__(self,in0 : Data, in1 : Data):
+                    return fun(in0,in1)
+            Binary.__name__ = name
+            return Binary
+        SmallIR.add_instruction(name,family_closure)
+    for name,fun in (
+        ("Add",lambda x,y: x+y),
+        ("Sub",lambda x,y: x-y),
+        ("And",lambda x,y: x&y)
+    ):
+        add_binary(name,fun)
+
+    def add_unary(name,fun):
+        def family_closure(family):
+            Data = family.BitVector[width]
+            class Unary(Peak):
+                @name_outputs(out=Data)
+                def __call__(self,in0 : Data):
+                    return fun(in0)
+            Unary.__name__ = name
+            return Unary
+        SmallIR.add_instruction(name,family_closure)
+
+    for name,fun in (
+        ("Not",lambda x: ~x),
+        ("Neg",lambda x: -x)
+    ):
+        add_unary(name,fun)
+
+    return SmallIR

--- a/peak/__init__.py
+++ b/peak/__init__.py
@@ -2,6 +2,6 @@
 from .register import gen_register
 from .memory import Memory, RAM, ROM
 
-from .peak import Peak, name_outputs, PeakNotImplementedError
+from .peak import Peak, get_isa, name_outputs, PeakNotImplementedError
 
 from .rtl_utils import wrap_with_disassembler

--- a/peak/ir.py
+++ b/peak/ir.py
@@ -1,0 +1,11 @@
+from collections import namedtuple
+import typing as tp
+
+class IR:
+    def __init__(self):
+        #Stores a list of instructions (name : family_closure)
+        self.instructions = {}
+    def add_instruction(self, name : str, semantics :  tp.Callable):
+        if name in self.instructions:
+            raise ValueError(f"{name} is already an existing instruction")
+        self.instructions[name] = semantics

--- a/peak/mapper/binding.py
+++ b/peak/mapper/binding.py
@@ -1,0 +1,83 @@
+import typing as tp
+import itertools as it
+from hwtypes import SMTBit, SMTBitVector, SMTSIntVector
+
+def _group_by_value(d : tp.Mapping[tp.Any, type]) -> tp.Mapping[type, tp.List[tp.Any]]:
+    nd = {}
+    for k,v in d.items():
+        nd.setdefault(v, []).append(k)
+
+    return nd
+
+#This will deal with bindings
+class Binder:
+    def __init__(self,
+        arch_inputs : tp.Mapping[str,type],
+        ir_inputs : tp.Mapping[str,type],
+        ir_smt_vars : tp.Mapping[str,SMTBitVector],
+    ):
+        self.arch_inputs = arch_inputs
+        self.ir_inputs = ir_inputs
+        self.ir_smt_vars = ir_smt_vars
+
+        #type : List[names]
+        arch_inputs_by_t = _group_by_value(arch_inputs)
+        ir_inputs_by_t = _group_by_value(ir_inputs)
+
+        #Cannot have more inputs in the ir instruction (for now)
+        assert ir_inputs_by_t.keys() <= arch_inputs_by_t.keys()
+
+        #for each type, each input of the type in the IR needs to at least be able to bind to one other in the arch
+        for t in ir_inputs_by_t:
+            assert len(arch_inputs_by_t[t]) >= len(ir_inputs_by_t[t])
+
+        possible_matching = {}
+        missing_inputs_by_t = {}
+        for arch_type, arch_input_names in arch_inputs_by_t.items():
+            #Returns this list of things that match type t from arch
+            ir_input_names = ir_inputs_by_t.setdefault(arch_type, [])
+            type_diff = len(arch_input_names) - len(ir_input_names)
+            missing_inputs_by_t[arch_type] = type_diff
+            #expand the list to be the same size as arch (with Nones)
+            ir_input_names = list(it.chain(ir_input_names, it.repeat(None, type_diff)))
+            assert len(ir_input_names) == len(arch_input_names)
+            #For every permutation of arch_input_names, match it with ir_input_names
+            for arch_perm in it.permutations(arch_input_names):
+                possible_matching.setdefault(arch_type, []).append(list(zip(ir_input_names, arch_perm)))
+
+        self.possible_matching = possible_matching
+        self.missing_inputs_by_t = missing_inputs_by_t
+
+        del arch_inputs_by_t
+        del ir_inputs_by_t
+
+    #Returns a list of all possible bindings
+    #TODO should be a generator
+    def get_bindings(self):
+        bindings = []
+        for l in it.product(*self.possible_matching.values()):
+            bindings.append(list(it.chain(*l)))
+        return bindings
+
+    #Will enumerate all possible missing input bindings
+    #TODO add in Constant values (0,-1) instead of just SMTVar
+    #TODO should be a generator
+    def get_missing_inputs_list(self) -> tp.List[tp.Mapping[type,SMTBitVector]]:
+        possible = {}
+        for t,cnt in self.missing_inputs_by_t.items():
+            possible[t] = [t() for _ in range(cnt)]
+        return [possible]
+
+    def construct_binding_dict(self,missing_inputs,binding):
+        tidx = {t:0 for t in missing_inputs}
+        binding_dict = {}
+        name_binding = {k : v if v is not None else "any" for v,k in binding}
+        for ir_name,arch_name in binding:
+            if ir_name is not None:
+                binding_dict[arch_name] = self.ir_smt_vars[ir_name]
+            else:
+                arch_type = self.arch_inputs[arch_name]
+                binding_dict[arch_name] = missing_inputs[arch_type][tidx[arch_type]]
+                tidx[arch_type] += 1
+        return binding_dict,name_binding
+

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -26,7 +26,7 @@ class ArchMapper:
     def __init__(self,
         arch_fclosure : tp.Callable,
         solver_name : str = 'z3',
-        constraints = []
+        isa_filters = []
     ):
         self.solver_name = solver_name
 
@@ -45,12 +45,12 @@ class ArchMapper:
         self.arch_inputs = _filter_adt_types(self.arch_inputs)
 
 
-        def constraint_filter(inst):
-            return all(constraint(inst) for constraint in constraints)
+        def isa_filter_fun(inst):
+            return all(isa_filters(inst) for isa_filter in isa_filters)
         logging.debug("Enumerating bv instructions")
-        self.bv_isa_list = list(filter(constraint_filter, self.bv_isa.enumerate()))
+        self.bv_isa_list = list(filter(isa_filter_fun, self.bv_isa.enumerate()))
         logging.debug("Enumerating smt instructions")
-        self.smt_isa_list = list(filter(constraint_filter, self.smt_isa.enumerate()))
+        self.smt_isa_list = list(filter(isa_filter_fun, self.smt_isa.enumerate()))
 
     def map_ir_op(self,
         ir_fclosure : tp.Callable,

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -2,7 +2,7 @@ import typing as tp
 import itertools as it
 import functools as ft
 import logging
-from ..peak import Peak
+from ..peak import Peak, get_isa
 import coreir
 from .binding import Binder
 from hwtypes import AbstractBitVector
@@ -14,7 +14,6 @@ from hwtypes import SMTBit, SMTBitVector, SMTSIntVector
 import pysmt.shortcuts as smt
 from pysmt.logics import QF_BV
 
-
 def _filter_adt_types(peak_io):
     io_map = {}
     for name,btype in peak_io.items():
@@ -23,7 +22,6 @@ def _filter_adt_types(peak_io):
         io_map[name] = btype
     return io_map
 
-
 class ArchMapper:
     def __init__(self,
         arch_fclosure : tp.Callable,
@@ -31,17 +29,11 @@ class ArchMapper:
         constraints = []
     ):
         self.solver_name = solver_name
-        def _get_isa(arch):
-            arch_inputs = arch.__call__._peak_inputs_
-            #Find the arch isa from the arch_inputs
-            _isa_list = list(filter(lambda t: is_adt_type(t), arch_inputs.values()))
-            assert len(_isa_list)==1
-            return _isa_list[0]
 
         #should contain instruction as first argument
         arch_smt = arch_fclosure(SMTBitVector.get_family())
-        self.smt_isa = _get_isa(arch_smt)
-        self.bv_isa = _get_isa(arch_fclosure(BitVector.get_family()))
+        self.smt_isa = get_isa(arch_smt)
+        self.bv_isa = get_isa(arch_fclosure(BitVector.get_family()))
 
         self.arch_sim = arch_smt()
 
@@ -106,7 +98,7 @@ class ArchMapper:
                         assert isinstance(rval, (SMTBit, SMTBitVector))
                         assert rval.value.get_type() == ir_smt_expr.value.get_type()
                         with smt.Solver(self.solver_name, logic=QF_BV) as solver:
-                            if check_equal(self.solver_name, binding_dict, rval, ir_smt_expr, name_binding):
+                            if self.check_equal(binding_dict, rval, ir_smt_expr, name_binding):
                                 #Create output and input map
                                 output_map = {"out":list(ir_outputs.items())[ridx][0]}
                                 input_map = name_binding
@@ -120,118 +112,15 @@ class ArchMapper:
                                 if found >= max_mappings:
                                     return
 
-
-def gen_mapping(
-        peak_class : Peak,
-        bv_isa : BoundMeta, #This is currently a hack that will be removed.
-        smt_isa : BoundMeta,
-        coreir_module : coreir.ModuleDef,
-        coreir_model : tp.Callable,
-        max_mappings : int,
-        *,
-        verbose : int = 0,
-        solver_name : str = 'z3',
-        constraints = []
-        ):
-
-    if verbose == 1:
-        logging.getLogger().setLevel(logging.DEBUG)
-    elif verbose == 2:
-        logging.getLogger().setLevel(logging.DEBUG - 1)
-
-    peak_inst = peak_class() #This cannot take any args
-
-    peak_inputs = _filter_io_types(peak_class.__call__._peak_inputs_)
-    peak_outputs = _filter_io_types(peak_class.__call__._peak_outputs_)
-
-    core_inputs = {k if k != 'in' else 'in_' : SMTBitVector[v.size] for k,v in coreir_module.type.items() if v.is_input()}
-    core_outputs = {k : SMTBitVector[v.size] for k,v in  coreir_module.type.items() if v.is_output()}
-    core_smt_vars = {k : v() for k,v in core_inputs.items()}
-    core_smt_expr = coreir_model(**core_smt_vars)
-
-    #The following is some really gross magic to generate all possible assignments
-    #of core inputs / costants (None) to peak inputs
-    core_inputs_by_t = _group_by_value(core_inputs)
-    peak_inputs_by_t = _group_by_value(peak_inputs)
-
-    assert core_inputs_by_t.keys() <= peak_inputs_by_t.keys()
-    for k in core_inputs_by_t:
-        assert len(core_inputs_by_t[k]) <= len(peak_inputs_by_t[k])
-
-    possible_matching = {}
-    for t, pi in peak_inputs_by_t.items():
-        ci = core_inputs_by_t.setdefault(t, [])
-        ci = list(it.chain(ci, it.repeat(None, len(pi) - len(ci))))
-        assert len(ci) == len(pi)
-        for perm in it.permutations(pi):
-            possible_matching.setdefault(t, []).append(list(zip(ci, perm)))
-
-    del core_inputs_by_t
-    del peak_inputs_by_t
-
-    bindings = []
-    for l in it.product(*possible_matching.values()):
-        bindings.append(list(it.chain(*l)))
-    found = 0
-    if found >= max_mappings:
-        return
-    def f_fun(inst):
-        return all(constraint(inst) for constraint in constraints)
-
-    logging.debug("Enumerating bv instructions")
-    bv_isa_list = list(filter(f_fun, bv_isa.enumerate()))
-    bv_isa_len = len(bv_isa_list)
-    logging.debug("Enumerating smt instructions")
-    smt_isa_list = list(filter(f_fun, smt_isa.enumerate()))
-    smt_isa_len = len(smt_isa_list)
-
-    logging.debug("Starting search")
-
-    for ii,smt_inst in enumerate(smt_isa_list):
-        logging.debug(f"inst {ii+1}/{bv_isa_len}")
-        logging.debug(smt_inst)
-
-        for bi,binding in enumerate(bindings):
-            binding_dict = {k : core_smt_vars[v] if v is not None else peak_inputs[k](0) for v,k in binding}
-            name_binding = {k : v if v is not None else 0 for v,k in binding}
-
-            rvals = peak_inst(smt_inst, **binding_dict)
-            if not isinstance(rvals, tuple):
-                rvals = rvals,
-
-            for idx, bv in enumerate(rvals):
-                if isinstance(bv, (SMTBit, SMTBitVector)) and bv.value.get_type() == core_smt_expr.value.get_type():
-                    with smt.Solver(solver_name, logic=QF_BV) as solver:
-                        if check_equal(solver_name, binding_dict, bv, core_smt_expr, name_binding):
-                            #Create output and input map
-                            output_map = {"out":list(peak_class.__call__._peak_outputs_.items())[idx][0]}
-                            input_map = {}
-                            for k,v in name_binding.items():
-                                if v == 0:
-                                    v = "0"
-                                elif v == "in_":
-                                    v = "in"
-                                input_map[v] = k
-
-                            mapping = dict(
-                                instruction=bv_isa_list[ii],
-                                output_map=output_map,
-                                input_map=input_map
-                            )
-                            yield mapping
-                            found  += 1
-                            if found >= max_mappings:
-                                return
-
-def check_equal(solver_name, smt_vars, expr1, expr2, name_binding):
-    with smt.Solver(solver_name, logic=QF_BV) as solver:
-        expr = expr1 != expr2
-        solver.add_assertion(expr.value)
-        if not solver.solve():
-            return True
-        else:
-            model = solver.get_model()
-            model = {k : model[v.value] for k,v in smt_vars.items()}
-            logging.log(logging.DEBUG - 1, name_binding)
-            logging.log(logging.DEBUG - 1, model)
-            return False
+    def check_equal(self, smt_vars, expr1, expr2, name_binding):
+        with smt.Solver(self.solver_name, logic=QF_BV) as solver:
+            expr = expr1 != expr2
+            solver.add_assertion(expr.value)
+            if not solver.solve():
+                return True
+            else:
+                model = solver.get_model()
+                model = {k : model[v.value] for k,v in smt_vars.items()}
+                logging.log(logging.DEBUG - 1, name_binding)
+                logging.log(logging.DEBUG - 1, model)
+                return False

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -4,6 +4,7 @@ import functools as ft
 import logging
 from ..peak import Peak
 import coreir
+from collections import Counter
 
 from hwtypes import AbstractBitVector
 from hwtypes import BitVector, SIntVector
@@ -14,6 +15,12 @@ from hwtypes import SMTBit, SMTBitVector, SMTSIntVector
 import pysmt.shortcuts as smt
 from pysmt.logics import QF_BV
 
+#Currently this only outputs SMT var, but could also enumerate constants
+def _enumerate_missing_inputs(mbt : tp.Mapping[type,int]) -> tp.List[tp.Mapping[type,SMTBitVector]]:
+    possible = {}
+    for t,cnt in mbt.items():
+        possible[t] = [t() for _ in range(cnt)]
+    return [possible]
 
 
 def _group_by_value(d : tp.Mapping[tp.Any, type]) -> tp.Mapping[type, tp.List[tp.Any]]:
@@ -23,14 +30,146 @@ def _group_by_value(d : tp.Mapping[tp.Any, type]) -> tp.Mapping[type, tp.List[tp
 
     return nd
 
-def _filter_io_types(peak_io):
-    width_map = {}
+def _filter_adt_types(peak_io):
+    io_map = {}
     for name,btype in peak_io.items():
         if is_adt_type(btype):
             continue
-        width_map[name] = btype
-    return width_map
+        io_map[name] = btype
+    return io_map
 
+def gen_mapping_ir(
+    ir_fclosure : tp.Callable,
+    arch_fclosure : tp.Callable,
+    max_mappings : int,
+    *,
+    verbose : int = 0,
+    solver_name : str = 'z3',
+    constraints = []
+):
+    if verbose == 1:
+        logging.getLogger().setLevel(logging.DEBUG)
+    elif verbose == 2:
+        logging.getLogger().setLevel(logging.DEBUG - 1)
+
+    #should contain instruction as first argument
+    arch_smt = arch_fclosure(SMTBitVector.get_family())
+    arch_sim = arch_smt()
+    #should only contain bitvectors as inputs
+    ir_smt = ir_fclosure(SMTBitVector.get_family())
+
+    arch_inputs = arch_smt.__call__._peak_inputs_
+    arch_outputs = arch_smt.__call__._peak_outputs_
+    ir_inputs = ir_smt.__call__._peak_inputs_
+    ir_outputs = ir_smt.__call__._peak_outputs_
+
+    #Find the arch isa from the arch_inputs
+    isa_list = list(filter(lambda t: is_adt_type(t), arch_inputs.values()))
+    assert len(isa_list)==1
+    smt_isa = isa_list[0]
+    bv_isa = smt_isa #Hack for now
+
+    #remove isa from arch_inputs list
+    arch_inputs = _filter_adt_types(arch_inputs)
+
+    #type : List[names]
+    arch_inputs_by_t = _group_by_value(arch_inputs)
+    ir_inputs_by_t = _group_by_value(ir_inputs)
+
+    #Cannot have more inputs in the ir instruction (for now)
+    assert ir_inputs_by_t.keys() <= arch_inputs_by_t.keys()
+
+    #for each type, each input of the type in the IR needs to at least be able to bind to one other in the arch
+    for t in ir_inputs_by_t:
+        assert len(arch_inputs_by_t[t]) >= len(ir_inputs_by_t[t])
+
+    possible_matching = {}
+    missing_inputs_by_t = {}
+    for arch_type, arch_input_names in arch_inputs_by_t.items():
+        #Returns this list of things that match type t from arch
+        ir_input_names = ir_inputs_by_t.setdefault(arch_type, [])
+        type_diff = len(arch_input_names) - len(ir_input_names)
+        missing_inputs_by_t[arch_type] = type_diff
+        #expand the list to be the same size as arch (with Nones)
+        ir_input_names = list(it.chain(ir_input_names, it.repeat(None, type_diff)))
+        assert len(ir_input_names) == len(arch_input_names)
+        #For every permutation of arch_input_names, match it with ir_input_names
+        for arch_perm in it.permutations(arch_input_names):
+            possible_matching.setdefault(arch_type, []).append(list(zip(ir_input_names, arch_perm)))
+
+    del arch_inputs_by_t
+    del ir_inputs_by_t
+
+    bindings = []
+    for l in it.product(*possible_matching.values()):
+        bindings.append(list(it.chain(*l)))
+    found = 0
+    if found >= max_mappings:
+        return
+    def f_fun(inst):
+        return all(constraint(inst) for constraint in constraints)
+    #--------
+
+    ir_smt_vars = {k : v() for k,v in ir_inputs.items()}
+    #This actually contains the symbolic representation
+    ir_smt_expr = ir_smt()(**ir_smt_vars)
+
+
+
+    missing_inputs_list = _enumerate_missing_inputs(missing_inputs_by_t)
+    def _construct_binding_dict(missing_inputs,binding):
+        tidx = {t:0 for t in missing_inputs}
+        binding_dict = {}
+        name_binding = {k : v if v is not None else "any" for v,k in binding}
+        for ir_name,arch_name in binding:
+            if ir_name is not None:
+                binding_dict[arch_name] = ir_smt_vars[ir_name]
+            else:
+                arch_type = arch_inputs[arch_name]
+                binding_dict[arch_name] = missing_inputs[arch_type][tidx[arch_type]]
+                tidx[arch_type] += 1
+        return binding_dict,name_binding
+
+    logging.debug("Enumerating bv instructions")
+    bv_isa_list = list(filter(f_fun, bv_isa.enumerate()))
+    bv_isa_len = len(bv_isa_list)
+    logging.debug("Enumerating smt instructions")
+    smt_isa_list = list(filter(f_fun, smt_isa.enumerate()))
+    smt_isa_len = len(smt_isa_list)
+
+    logging.debug("Starting search")
+
+    for ii,smt_inst in enumerate(smt_isa_list):
+        logging.debug(f"inst {ii+1}/{bv_isa_len}")
+        logging.debug(smt_inst)
+
+        for bi,binding in enumerate(bindings):
+
+            #enumerate possibilities for missing inputs
+            for missing_inputs in missing_inputs_list:
+                #building binding_dict
+                binding_dict,name_binding = _construct_binding_dict(missing_inputs,binding)
+                rvals = arch_sim(smt_inst, **binding_dict)
+                if not isinstance(rvals, tuple):
+                    rvals = rvals,
+
+                for ridx, rval in enumerate(rvals):
+                    assert isinstance(rval, (SMTBit, SMTBitVector))
+                    assert rval.value.get_type() == ir_smt_expr.value.get_type()
+                    with smt.Solver(solver_name, logic=QF_BV) as solver:
+                        if check_equal(solver_name, binding_dict, rval, ir_smt_expr, name_binding):
+                            #Create output and input map
+                            output_map = {"out":list(ir_outputs.items())[ridx][0]}
+                            input_map = name_binding
+                            mapping = dict(
+                                instruction=bv_isa_list[ii],
+                                output_map=output_map,
+                                input_map=input_map
+                            )
+                            yield mapping
+                            found  += 1
+                            if found >= max_mappings:
+                                return
 
 def gen_mapping(
         peak_class : Peak,

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -9,7 +9,7 @@ def name_outputs(**outputs):
     """Decorator meant to apply to any function to specify output types
     The output types will be stored in fn._peak_outputs__
     The input types will be stored in fn._peak_inputs_
-    The ISA will be stored in fn._peak_isa_
+    The ISA will be stored in fn._peak_isa_ (if it exists as first arg)
     Will verify that all the inputs have type annotations
     Will also verify that the outputs of running fn will have the correct number of bits
     """
@@ -46,18 +46,10 @@ def name_outputs(**outputs):
             in_type_keys.remove("return")
         if set(input_names) != set(in_type_keys):
             raise TypeError(f"Missing type annotations on inputs: {set(input_names)} != {set(in_type_keys)}")
-        isa = []
         for name in input_names:
             input_type= in_types[name]
-            if is_adt_type(input_type):
-                isa.append((name,input_type))
-                continue
             call_wrapper._peak_inputs_[name] = in_types[name]
-        if len(isa) == 0:
-            raise TypeError("Need to pass peak ISA instruction to __call__")
-        if len(isa) > 1:
-            raise NotImplementedError("Can only pass in single instruction")
-        call_wrapper._peak_isa_ = isa[0]
+
         return call_wrapper
     return decorator
 

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -5,11 +5,20 @@ import functools
 class Peak:
     pass
 
+
+#This will get the isa from the peak class
+def get_isa(peak_class):
+    inputs = peak_class.__call__._peak_inputs_
+    #Find the arch isa from the arch_inputs
+    _isa_list = list(filter(lambda t: is_adt_type(t), inputs.values()))
+    assert len(_isa_list)==1
+    return _isa_list[0]
+
+
 def name_outputs(**outputs):
     """Decorator meant to apply to any function to specify output types
     The output types will be stored in fn._peak_outputs__
     The input types will be stored in fn._peak_inputs_
-    The ISA will be stored in fn._peak_isa_ (if it exists as first arg)
     Will verify that all the inputs have type annotations
     Will also verify that the outputs of running fn will have the correct number of bits
     """

--- a/tests/test_alu.py
+++ b/tests/test_alu.py
@@ -1,8 +1,8 @@
 from peak import PeakNotImplementedError
-from examples.alu import gen_alu, Inst, ALUOP
+from examples.alu import gen_ALU, Inst, ALUOP
 from hwtypes import BitVector
 
-ALU = gen_alu(BitVector.get_family(),width=16)
+ALU = gen_ALU(width=16)(BitVector.get_family())
 alu = ALU()
 Data = BitVector[16]
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,10 +1,10 @@
 from examples.pe1 import PE, Inst, Bit, Data
-
+from peak import get_isa
 
 def test_inputs():
     #Expected inputs
-    expected_names = ["data0", "data1", "bit0", "bit1", "bit2", "clk_en"]
-    expected_types = [Data,Data,Bit,Bit,Bit,Bit]
+    expected_names = ["inst","data0", "data1", "bit0", "bit1", "bit2", "clk_en"]
+    expected_types = [Inst,Data,Data,Bit,Bit,Bit,Bit]
 
     assert hasattr(PE.__call__,"_peak_inputs_")
     inputs = PE.__call__._peak_inputs_
@@ -24,6 +24,5 @@ def test_outputs():
         assert otype == expected_types[i]
 
 def test_isa():
-    assert hasattr(PE.__call__,"_peak_isa_")
-    isa = PE.__call__._peak_isa_
-    assert isa == ("inst",Inst)
+    isa = get_isa(PE)
+    assert isa == Inst

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,14 +1,20 @@
 from examples.smallir import gen_SmallIR
 from examples.alu import gen_ALU
-from peak.mapper import gen_mapping_ir
+from peak.mapper import ArchMapper
 
 #This test will try to run the ir mapper function
 def test_smallir():
     #arch
     arch_fc = gen_ALU()
 
+    ALUMapper = ArchMapper(arch_fc)
+
     #IR
     SmallIR = gen_SmallIR(16)
+
     for name,ir_fc in SmallIR.instructions.items():
-        mapping = gen_mapping_ir(ir_fc,arch_fc,1)
-        assert len(list(mapping)) > 0
+        mapping = list(ALUMapper.map_ir_op(ir_fc))
+        print(mapping)
+        assert len(mapping) > 0
+
+test_smallir()

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,0 +1,14 @@
+from examples.smallir import gen_SmallIR
+from examples.alu import gen_ALU
+from peak.mapper import gen_mapping_ir
+
+#This test will try to run the ir mapper function
+def test_smallir():
+    #arch
+    arch_fc = gen_ALU()
+
+    #IR
+    SmallIR = gen_SmallIR(16)
+    for name,ir_fc in SmallIR.instructions.items():
+        mapping = gen_mapping_ir(ir_fc,arch_fc,1)
+        assert len(list(mapping)) > 0


### PR DESCRIPTION
Does the following:
-Simplifies/generalizes api for generating rewrite rules
-Removes CoreIR dependency
-Modularizes the mapping/binding code (to an extent)
-Defines an 'IR' object that can be dynamically constructed.

Still TODO
-Better mapping test
-Update downstream tools (mostly MetaMapper) to use new API