### PR TITLE
Rebinding peak classes to different families

### DIFF
--- a/peak/__init__.py
+++ b/peak/__init__.py
@@ -2,6 +2,6 @@
 from .register import gen_register
 from .memory import Memory, RAM, ROM
 
-from .peak import Peak, name_outputs, PeakNotImplementedError
+from .peak import Peak, name_outputs, rebind_type, PeakNotImplementedError
 
 from .rtl_utils import wrap_with_disassembler

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -9,9 +9,9 @@ import textwrap
 def _rebind_type(T,family):
     if T in (AbstractBitVector,AbstractBit,Product,Sum,Tuple, Enum):
         return T
-    if not inspect.isclass(T):
+    elif not inspect.isclass(T):
         return T
-    if issubclass(T,AbstractBitVector):
+    elif issubclass(T,AbstractBitVector):
         if T.size is None: #This is BitVector
             return family.BitVector
         else:

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -19,7 +19,7 @@ def _rebind_type(T,family):
     elif issubclass(T,AbstractBit):
         return family.Bit
     elif issubclass(T,Product):
-        return Product.from_fields(T.__name__,{field:_rebind_type(t,family) for field,t in T.field_dict.items()})
+        return Product.from_fields(T.__name__,{field:_rebind_type(t,family) for field,t in T.field_dict.items()},None,None)
     elif issubclass(T,Enum):
         return T
     elif issubclass(T,Sum):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "peak",
     ],
     install_requires=[
-        "hwtypes >= 1.0.1",
+        "hwtypes >= 1.1.1",
         "astor",
         "pysmt",
         "magma-lang",

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,32 @@
+from peak import Peak, name_outputs
+from hwtypes import BitVector, SMTBitVector
+
+def test_meta():
+    x = 5
+    stack = 4
+    env = 3
+    class A(Peak):
+        def __init__(self):
+            self.x = x
+            self.stack = stack
+    assert hasattr(A,"_env_")
+    assert A._env_['x'] == 5
+    assert A._env_['stack'] == 4
+    assert A._env_['env'] == 3
+
+def test_rebind():
+    Data = BitVector[16]
+    class B(Peak):
+        def __init__(self):
+            self.Data = Data
+        def __call__(self,a : Data):
+            return a + BitVector[16](5)
+    assert Data(6) == B()(Data(1))
+    B_smt = B.rebind(SMTBitVector.get_family())
+    assert B_smt().Data == SMTBitVector[16]
+    try:
+        b_sym = B_smt()(SMTBitVector[16]())
+        print(b_sym)
+    except:
+        assert 0
+test_rebind()

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -16,6 +16,20 @@ def test_meta():
     assert A._env_['stack'] == 4
     assert A._env_['env'] == 3
 
+    def f():
+        x = 4
+        stack = 2
+        env = 1
+        class A1(Peak):
+            pass
+        return A1
+    A1 = f()
+    assert hasattr(A1,"_env_")
+    assert A1._env_['x'] == 4
+    assert A1._env_['stack'] == 2
+    assert A1._env_['env'] == 1
+
+
 def test_rebind():
     Data = BitVector[16]
     #Bug in inspect.getsource if I try to name this class to A


### PR DESCRIPTION
This is an attempt to simplify writing peak classes to not require the need for a family closure.
This PR does the following:
-Defines a peak metaclass that captures the locals and globals (using code similar to magma.circuit.sequential) in an attribute called `_env_` 
-Defines a rebind(family) function that returns a new class where all references to types derived from family (ADT types, BitVector, Bit) are transformed to the appropriate version from the passed in family

Limitations:
-Defining multiple classes with the same name in the same file causes problems due to inspect.getsource() getting incorrect code.
-Calling a function that returns a family type within the definition of the inherited peak class will cause rebind to not work correctly.

TODO:
-should move the _rebind_types() function into hwtypes
-should add more tests