### PR TITLE
Patch travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
 cache:
   apt: true
 addons:
-  sources:
-    - ubuntu-toolchain-r-test
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
     - libgmp-dev
     - libmpfr-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
 - export CXX="g++-7"  # For coreir/verilogAST
 - git clone https://github.com/leonardt/verilogAST-cpp
 - cd verilogAST-cpp
-- export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 - mkdir build && cd build && cmake .. && cmake --build . && sudo make install && cd ..
 - cd ..  # verilogAST-cpp
 - curl -s -L https://github.com/rdaly525/coreir/releases/latest | grep "href.*coreir.tar.gz" | cut -d \" -f 2 | xargs -I {} wget https://github.com"{}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 - git clone https://github.com/leonardt/verilogAST-cpp
 - cd verilogAST-cpp
 - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-- mkdir build && cd build && cmake .. && sudo cmake --build . --target install && cd ..
+- mkdir build && cd build && cmake .. && cmake --build . && sudo make install && cd ..
 - cd ..  # verilogAST-cpp
 - pip install -U pip
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,17 @@ python:
 cache:
   apt: true
 addons:
+  sources:
+    - ubuntu-toolchain-r-test
   apt:
     packages:
     - libgmp-dev
     - libmpfr-dev
     - libmpc-dev
     - verilator
+    - g++-7
 before_install:
+- export CXX="g++-7"  # For coreir/verilogAST
 - pip install -U pip
 install:
 - pip install pytest-cov fault mantle

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,7 @@ before_install:
 - export CXX="g++-7"  # For coreir/verilogAST
 - git clone https://github.com/leonardt/verilogAST-cpp
 - cd verilogAST-cpp
-- mkdir build
-- cd build
-- cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
-- cmake --build .
-- sudo make install
-- cd ..  # build
+- mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && cmake --build . --target install --config Release && cd ..
 - cd ..  # verilogAST-cpp
 - pip install -U pip
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,15 @@ addons:
     - g++-7
 before_install:
 - export CXX="g++-7"  # For coreir/verilogAST
+- git clone https://github.com/leonardt/verilogAST-cpp
+- cd verilogAST-cpp
+- mkdir build
+- cd build
+- cmake ..
+- cmake --build .
+- make install
+- cd ..  # build
+- cd ..  # verilogAST-cpp
 - pip install -U pip
 install:
 - pip install pytest-cov fault mantle

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 - cd verilogAST-cpp
 - mkdir build
 - cd build
-- cmake ..
+- cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
 - cmake --build .
 - sudo make install
 - cd ..  # build

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 - cd build
 - cmake ..
 - cmake --build .
-- make install
+- sudo make install
 - cd ..  # build
 - cd ..  # verilogAST-cpp
 - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_install:
 - export CXX="g++-7"  # For coreir/verilogAST
 - git clone https://github.com/leonardt/verilogAST-cpp
 - cd verilogAST-cpp
-- mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && sudo cmake --build . --target install --config Release && cd ..
+- export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+- mkdir build && cd build && cmake .. && sudo cmake --build . --target install && cd ..
 - cd ..  # verilogAST-cpp
 - pip install -U pip
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 - export CXX="g++-7"  # For coreir/verilogAST
 - git clone https://github.com/leonardt/verilogAST-cpp
 - cd verilogAST-cpp
-- mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && cmake --build . --target install --config Release && cd ..
+- mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && sudo cmake --build . --target install --config Release && cd ..
 - cd ..  # verilogAST-cpp
 - pip install -U pip
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ before_install:
 - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 - mkdir build && cd build && cmake .. && cmake --build . && sudo make install && cd ..
 - cd ..  # verilogAST-cpp
+- curl -s -L https://github.com/rdaly525/coreir/releases/latest | grep "href.*coreir.tar.gz" | cut -d \" -f 2 | xargs -I {} wget https://github.com"{}"
+- mkdir coreir_release;
+- tar -xf coreir.tar.gz -C coreir_release --strip-components 1;
+- cd coreir_release && sudo make install && cd ..
 - pip install -U pip
 install:
 - pip install pytest-cov fault mantle


### PR DESCRIPTION
There were a few issues, first g++-7 is needed for libverilogAST, then the new pycoreir release doesn't work with the standard static build so the workaround is to install coreir first (so it uses the existing installation).