### PR TITLE
Added object constructor 'from_fields' for assembledADT types

### DIFF
--- a/examples/min_pe/map_example.py
+++ b/examples/min_pe/map_example.py
@@ -93,7 +93,7 @@ precondition = (
 sim_expr = sim(inst)
 for target in targets:
     target_expr = target(x, y)
-    with smt.Solver('cvc4', logic=BV) as solver:
+    with smt.Solver('z3', logic=BV) as solver:
         solver.add_assertion(precondition.value)
         constraint = smt.ForAll([x.value, y.value, free_bit.value], (sim_expr == target_expr).value)
         solver.add_assertion(constraint)

--- a/peak/assembler/assembled_adt.py
+++ b/peak/assembler/assembled_adt.py
@@ -1,8 +1,10 @@
 import typing as tp
 from .assembler_abc import AssemblerMeta
-from hwtypes import AbstractBitVectorMeta, TypeFamily, Enum, Sum
+from hwtypes import AbstractBitVectorMeta, TypeFamily, Enum, Sum, Product, Tuple
 from hwtypes import AbstractBitVector, AbstractBit
 from hwtypes.adt_meta import BoundMeta
+
+from uuid import uuid1
 
 from .assembler_util import _issubclass
 
@@ -15,8 +17,163 @@ RESERVED_NAMES = frozenset({
     'bv_type',
 })
 
+#Given a layout specification and subfield values, construct a bitvector using concatenation
+def _create_from_layout(width, bv_vals, layout, default_bv : AbstractBitVector[1]):
+
+    #Check the layout is mutually exclusive
+    used_slots = [0 for _ in range(width)]
+    for (lo, hi) in layout.values():
+        for i in range(lo, hi):
+            used_slots[i] +=1
+    assert all(x < 2 for x in used_slots)
+
+    #Pad all the empty slots with default_bv
+    for i in range(width):
+        if used_slots[i] == 0:
+            k = uuid1()
+            layout[k] = (i, i+1)
+            bv_vals[k] = default_bv
+
+    def _get_lo(kv):
+        lo, hi = kv[1]
+        return lo
+    #I need to organize values by layout order.
+    sorted_layout = sorted(layout.items(), key=_get_lo)
+
+    #make sure augemnted layout is packed tightly
+    idx = 0
+    for v in sorted_layout:
+        lo, hi = v[1]
+        assert idx == lo
+        idx = hi
+    assert idx == width
+
+    val = bv_vals[sorted_layout[0][0]]
+    for name, _ in sorted_layout[1:]:
+        val = val.concat(bv_vals[name])
+
+    assert val.size == width
+    return val
+
+#method that returns the bitvector of a subfield
+def _field_to_bv(aadt_t, v):
+    if (_issubclass(aadt_t, AbstractBitVector)
+        or _issubclass(aadt_t, AbstractBit)):
+        bv_t = aadt_t.get_family().BitVector
+        if not isinstance(v, aadt_t):
+            raise TypeError(f'expected {aadt_t}, not {v}')
+        if _issubclass(aadt_t, AbstractBitVector):
+            bv_value = v
+        else:
+            bv_value = v.ite(bv_t[1](1), bv_t[1](0))
+    else:
+        bv_t = aadt_t.bv_type
+        sub_assembler = aadt_t.assembler_t(aadt_t.adt_t)
+        if isinstance(v, aadt_t):
+            bv_value = v._value_
+        elif isinstance(v, aadt_t.adt_t):
+            bv_value = sub_assembler.assemble(v, bv_t)
+        elif isinstance(v, bv_t[sub_assembler.width]):
+            bv_value = v
+        else:
+            raise TypeError(f'expected {aadt_t} or {aadt_t.adt_t} or {bv_t[sub_assembler.width]} but not {v}')
+    return bv_value
+
+def _create_from_product(assembled_adt):
+    adt_t, assembler_t, bv_t = assembled_adt.fields
+    assembler = assembler_t(adt_t)
+    #kwargs should be correctly passed by names
+    def _product(**kwargs):
+        bv_values = {}
+        for k, v in kwargs.items():
+            aadt_t = getattr(assembled_adt, k)
+            bv_values[k] = _field_to_bv(aadt_t, v)
+        bv_value = _create_from_layout(assembler.width, bv_values, assembler.layout, default_bv=bv_t[1](0) )
+        return assembled_adt(bv_value)
+    return _product
+
+def _create_from_tuple(assembled_adt):
+    adt_t, assembler_t, bv_t = assembled_adt.fields
+    assembler = assembler_t(adt_t)
+    #kwargs should be correctly passed by names
+    def _tuple(*args):
+        bv_values = {}
+        for idx, v in enumerate(args):
+            aadt_t = assembled_adt[idx]
+            bv_values[idx] = _field_to_bv(aadt_t, v)
+        bv_value = _create_from_layout(assembler.width, bv_values, assembler.layout, default_bv=bv_t[1](0))
+        return assembled_adt(bv_value)
+    return _tuple
+
+class _TAG: pass
+
+def _create_from_sum(assembled_adt):
+    adt_t, assembler_t, bv_t = assembled_adt.fields
+    assembler = assembler_t(adt_t)
+
+    def _sum(value):
+        #I need to figure out how to pass this value into _field_to_bv
+        bv_values = []
+        for name, field in adt_t.field_dict.items():
+            aadt_t = assembled_adt[field]
+            try:
+                bv_value = _field_to_bv(aadt_t, value)
+                bv_values.append((name, field, bv_value))
+            except TypeError:
+                pass
+        #Only one of the Sum types should match
+        if len(bv_values) == 0:
+            raise TypeError(f'{value} not valid for sum type {assembled_adt}')
+        elif len(bv_values) > 1:
+            raise TypeError(f'{value} is ambiguous for sum type {assembled_adt}')
+
+        #Construct the layout of the Tag and the one field
+        name, field, bv_value  = bv_values[0]
+        layout = {_TAG: assembler._tag_layout, field: assembler.layout[field]}
+        tag_val = assembler._tag_asm(field)
+        tag_bv = bv_t[assembler._tag_width](tag_val)
+        bv_values = {_TAG: tag_bv, field: bv_value}
+        bv_value = _create_from_layout(assembler.width, bv_values, layout, default_bv=bv_t[1](0))
+        return assembled_adt(bv_value)
+    return _sum
 
 class AssembledADTMeta(BoundMeta):
+
+    def __init__(cls, name, bases, namespace, **kwargs):
+        if not cls.is_bound:
+            return
+        if issubclass(cls.adt_t, Product):
+            type_sig = ', '.join(f'{k}: {v.__name__!r}' for k, v in cls.adt_t.field_dict.items())
+            # build from_fields
+            _product = _create_from_product(cls)
+            _call_product = ', '.join(f'{k}={k}' for k in cls.adt_t.field_dict)
+            from_fields = f'''
+def from_fields({type_sig}):
+    return _product({_call_product})
+'''
+            gs = dict(
+                _product=_product
+            )
+            ls = {}
+            exec(from_fields, gs, ls)
+            cls.from_fields = ls['from_fields']
+        elif issubclass(cls.adt_t, Tuple):
+            type_sig = ", ".join(f'_{k}: {v.__name__!r}' for k, v in cls.adt_t.field_dict.items())
+            _tuple = _create_from_tuple(cls)
+            _call_tuple = ', '.join(f'_{k}' for k in cls.adt_t.field_dict)
+            from_fields = f'''
+def from_fields({type_sig}):
+    return _tuple({_call_tuple})
+'''
+            gs = dict(
+                _tuple=_tuple
+            )
+            ls = {}
+            exec(from_fields, gs, ls)
+            cls.from_fields = ls['from_fields']
+        elif issubclass(cls.adt_t, Sum):
+            cls.from_fields = _create_from_sum(cls)
+
     def _name_cb(cls, idx):
         return f'{cls.__name__}[{", ".join(map(repr, idx))}]'
 
@@ -54,6 +211,7 @@ class AssembledADTMeta(BoundMeta):
         if isinstance(other, mcs):
             return super().__eq__(other)
         elif isinstance(other, BoundMeta) or isinstance(other, Enum):
+            #This looks sketchy. Does it work for SMT?
             return cls.bv_type.get_family().Bit(cls.adt_t == other)
         elif isinstance(other, BitVector) and isinstance(cls.adt_t, Enum):
             assembler = cls.assembler(type(cls.adt_t))
@@ -79,7 +237,6 @@ class AssembledADTMeta(BoundMeta):
     @property
     def bv_type(cls):
         return cls.fields[2]
-
 
 class AssembledADT(metaclass=AssembledADTMeta):
     def __init__(self, adt):

--- a/peak/assembler/assembled_adt.py
+++ b/peak/assembler/assembled_adt.py
@@ -15,6 +15,7 @@ RESERVED_NAMES = frozenset({
     'adt_t',
     'assembler_t',
     'bv_type',
+    'from_subfields'
 })
 
 #Given a layout specification and subfield values, construct a bitvector using concatenation
@@ -144,35 +145,35 @@ class AssembledADTMeta(BoundMeta):
             return
         if issubclass(cls.adt_t, Product):
             type_sig = ', '.join(f'{k}: {v.__name__!r}' for k, v in cls.adt_t.field_dict.items())
-            # build from_fields
+            # build from_subfields
             _product = _create_from_product(cls)
             _call_product = ', '.join(f'{k}={k}' for k in cls.adt_t.field_dict)
-            from_fields = f'''
-def from_fields({type_sig}):
+            from_subfields = f'''
+def from_subfields({type_sig}):
     return _product({_call_product})
 '''
             gs = dict(
                 _product=_product
             )
             ls = {}
-            exec(from_fields, gs, ls)
-            cls.from_fields = ls['from_fields']
+            exec(from_subfields, gs, ls)
+            cls.from_subfields = ls['from_subfields']
         elif issubclass(cls.adt_t, Tuple):
             type_sig = ", ".join(f'_{k}: {v.__name__!r}' for k, v in cls.adt_t.field_dict.items())
             _tuple = _create_from_tuple(cls)
             _call_tuple = ', '.join(f'_{k}' for k in cls.adt_t.field_dict)
-            from_fields = f'''
-def from_fields({type_sig}):
+            from_subfields = f'''
+def from_subfields({type_sig}):
     return _tuple({_call_tuple})
 '''
             gs = dict(
                 _tuple=_tuple
             )
             ls = {}
-            exec(from_fields, gs, ls)
-            cls.from_fields = ls['from_fields']
+            exec(from_subfields, gs, ls)
+            cls.from_subfields = ls['from_subfields']
         elif issubclass(cls.adt_t, Sum):
-            cls.from_fields = _create_from_sum(cls)
+            cls.from_subfields = _create_from_sum(cls)
 
     def _name_cb(cls, idx):
         return f'{cls.__name__}[{", ".join(map(repr, idx))}]'

--- a/tests/test_assembled_adt.py
+++ b/tests/test_assembled_adt.py
@@ -14,7 +14,7 @@ import pytest
 FooBV = make_modifier('Foo')(BitVector)
 BarBV = make_modifier('Bar')(BitVector)
 
-def test_from_fields():
+def test_from_subfields():
     BV = BitVector[3]
     class E(Enum):
         a=1
@@ -50,16 +50,16 @@ def test_from_fields():
     s_t = S(t)
 
     AA = AssembledADT[A, Assembler, BitVector]
-    assert hasattr(AA, "from_fields")
+    assert hasattr(AA, "from_subfields")
     AB = AssembledADT[B, Assembler, BitVector]
-    assert hasattr(AB, "from_fields")
+    assert hasattr(AB, "from_subfields")
     AT = AssembledADT[T, Assembler, BitVector]
-    assert hasattr(AT, "from_fields")
+    assert hasattr(AT, "from_subfields")
     AS = AssembledADT[S, Assembler, BitVector]
-    assert hasattr(AS, "from_fields")
+    assert hasattr(AS, "from_subfields")
 
     #This is really what I want to do. 
-    aa = AA.from_fields(
+    aa = AA.from_subfields(
         a=Bit(0),
         b=BV(3),
         e=E.b
@@ -69,7 +69,7 @@ def test_from_fields():
     assert aa.b == BV(3)
     assert aa.e == E.b
 
-    ab = AB.from_fields(
+    ab = AB.from_subfields(
         a=aa,
         b=Bit(1)
     )
@@ -77,13 +77,13 @@ def test_from_fields():
     assert ab.a == aa
     assert ab.b == Bit(1)
 
-    at = AT.from_fields(aa, e)
+    at = AT.from_subfields(aa, e)
     assert at == AT(t)
     assert at[0] == aa
     assert at[1] == e
 
-    as_b = AS.from_fields(ab)
-    as_t = AS.from_fields(t)
+    as_b = AS.from_subfields(ab)
+    as_t = AS.from_subfields(t)
     assert as_b == AS(s_b)
     assert as_t == AS(s_t)
     assert as_b.match(B)

--- a/tests/test_assembled_adt.py
+++ b/tests/test_assembled_adt.py
@@ -14,6 +14,84 @@ import pytest
 FooBV = make_modifier('Foo')(BitVector)
 BarBV = make_modifier('Bar')(BitVector)
 
+def test_from_fields():
+    BV = BitVector[3]
+    class E(Enum):
+        a=1
+        b=4
+
+    e = E.b
+
+    class A(Product):
+        a = Bit
+        b = BV
+        e = E
+
+    a = A(
+        a=Bit(0),
+        b=BV(3),
+        e=e
+    )
+
+    class B(Product):
+        a = A
+        b = Bit
+
+    b = B(
+        a=a,
+        b=Bit(1)
+    )
+
+    T = Tuple[A, E]
+    t = T(a, e)
+
+    S = Sum[B, T]
+    s_b = S(b)
+    s_t = S(t)
+
+    AA = AssembledADT[A, Assembler, BitVector]
+    assert hasattr(AA, "from_fields")
+    AB = AssembledADT[B, Assembler, BitVector]
+    assert hasattr(AB, "from_fields")
+    AT = AssembledADT[T, Assembler, BitVector]
+    assert hasattr(AT, "from_fields")
+    AS = AssembledADT[S, Assembler, BitVector]
+    assert hasattr(AS, "from_fields")
+
+    #This is really what I want to do. 
+    aa = AA.from_fields(
+        a=Bit(0),
+        b=BV(3),
+        e=E.b
+    )
+    assert aa == AA(a)
+    assert aa.a == Bit(0)
+    assert aa.b == BV(3)
+    assert aa.e == E.b
+
+    ab = AB.from_fields(
+        a=aa,
+        b=Bit(1)
+    )
+    assert ab == AB(b)
+    assert ab.a == aa
+    assert ab.b == Bit(1)
+
+    at = AT.from_fields(aa, e)
+    assert at == AT(t)
+    assert at[0] == aa
+    assert at[1] == e
+
+    as_b = AS.from_fields(ab)
+    as_t = AS.from_fields(t)
+    assert as_b == AS(s_b)
+    assert as_t == AS(s_t)
+    assert as_b.match(B)
+    assert not as_b.match(T)
+    assert as_b[B] == ab
+    assert as_t.match(T)
+    assert not as_t.match(B)
+    assert as_t[T] == at
 
 @pytest.mark.parametrize("isa", [pe5_isa, arm_isa, pico_isa])
 @pytest.mark.parametrize("bv_type", [BarBV, FooBV])


### PR DESCRIPTION
This enables me to construct an assembledADT object from its subfields which can also be assembledADT objects.

This is essential for the auto-mapper.