### PR TITLE
simplified peak inputs and outputs

### DIFF
--- a/peak/peak.py
+++ b/peak/peak.py
@@ -1,15 +1,27 @@
 from collections import OrderedDict
 from hwtypes import TypeFamily, AbstractBitVector, AbstractBit, BitVector, Bit, is_adt_type
+from hwtypes.adt import Product
 import functools
 
-class Peak:
-    pass
+class PeakMeta(type):
+    @property
+    def input_t(cls):
+        if not hasattr(cls.__call__, '_peak_inputs_'):
+            raise ValueError("Missing type annotations. Did you forget to decorate __call__ with 'name_outputs'")
+        return cls.__call__._peak_inputs_
+
+    @property
+    def output_t(cls):
+        if not hasattr(cls.__call__, '_peak_outputs_'):
+            raise ValueError("Missing type annotations. Did you forget to decorate __call__ with 'name_outputs'")
+        return cls.__call__._peak_outputs_
+
+class Peak(metaclass=PeakMeta): pass
 
 def name_outputs(**outputs):
     """Decorator meant to apply to any function to specify output types
-    The output types will be stored in fn._peak_outputs__
-    The input types will be stored in fn._peak_inputs_
-    The ISA will be stored in fn._peak_isa_
+    The output type will be stored in fn._peak_outputs__
+    The input type will be stored in fn._peak_inputs_
     Will verify that all the inputs have type annotations
     Will also verify that the outputs of running fn will have the correct number of bits
     """
@@ -28,15 +40,16 @@ def name_outputs(**outputs):
             return results
 
         #Set all the outputs
-        call_wrapper._peak_outputs_ = OrderedDict()
+        peak_outputs = OrderedDict()
         for oname,otype in outputs.items():
             if not issubclass(otype, (AbstractBitVector, AbstractBit)):
                 raise TypeError(f"{oname} is not a Bitvector class")
-            call_wrapper._peak_outputs_[oname] = otype
+            peak_outputs[oname] = otype
+        call_wrapper._peak_outputs_ = Product.from_fields("Output",peak_outputs)
 
         #set all the inputs
         arg_offset = 1 if call_fn.__name__ == "__call__" else 0
-        call_wrapper._peak_inputs_ = OrderedDict()
+        peak_inputs = OrderedDict()
         num_inputs = call_fn.__code__.co_argcount
         input_names = call_fn.__code__.co_varnames[arg_offset:num_inputs]
         in_types = call_fn.__annotations__
@@ -46,18 +59,10 @@ def name_outputs(**outputs):
             in_type_keys.remove("return")
         if set(input_names) != set(in_type_keys):
             raise TypeError(f"Missing type annotations on inputs: {set(input_names)} != {set(in_type_keys)}")
-        isa = []
         for name in input_names:
             input_type= in_types[name]
-            if is_adt_type(input_type):
-                isa.append((name,input_type))
-                continue
-            call_wrapper._peak_inputs_[name] = in_types[name]
-        if len(isa) == 0:
-            raise TypeError("Need to pass peak ISA instruction to __call__")
-        if len(isa) > 1:
-            raise NotImplementedError("Can only pass in single instruction")
-        call_wrapper._peak_isa_ = isa[0]
+            peak_inputs[name] = in_types[name]
+        call_wrapper._peak_inputs_ = Product.from_fields("Input", peak_inputs)
         return call_wrapper
     return decorator
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,4 +1,4 @@
-from peak.pe1 import PE, Inst, Bit, Data
+from examples.pe1 import PE, Inst, Bit, Data
 from hwtypes.adt import Product
 
 def test_inputs():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,14 +1,14 @@
-from examples.pe1 import PE, Inst, Bit, Data
-
+from peak.pe1 import PE, Inst, Bit, Data
+from hwtypes.adt import Product
 
 def test_inputs():
     #Expected inputs
-    expected_names = ["data0", "data1", "bit0", "bit1", "bit2", "clk_en"]
-    expected_types = [Data,Data,Bit,Bit,Bit,Bit]
+    expected_names = ["inst", "data0", "data1", "bit0", "bit1", "bit2", "clk_en"]
+    expected_types = [Inst,Data,Data,Bit,Bit,Bit,Bit]
 
-    assert hasattr(PE.__call__,"_peak_inputs_")
-    inputs = PE.__call__._peak_inputs_
-    for i, (iname,itype) in enumerate(inputs.items()):
+    input_t = PE.input_t
+    assert issubclass(input_t, Product)
+    for i, (iname,itype) in enumerate(input_t.field_dict.items()):
         assert iname == expected_names[i]
         assert itype == expected_types[i]
 
@@ -17,13 +17,9 @@ def test_outputs():
     expected_names = ["alu_res", "res_p", "irq"]
     expected_types = [Data,Bit,Bit]
 
-    assert hasattr(PE.__call__,"_peak_outputs_")
-    outputs = PE.__call__._peak_outputs_
-    for i, (oname,otype) in enumerate(outputs.items()):
+    output_t = PE.output_t
+    assert issubclass(output_t, Product)
+    for i, (oname,otype) in enumerate(output_t.field_dict.items()):
         assert oname == expected_names[i]
         assert otype == expected_types[i]
 
-def test_isa():
-    assert hasattr(PE.__call__,"_peak_isa_")
-    isa = PE.__call__._peak_isa_
-    assert isa == ("inst",Inst)


### PR DESCRIPTION
When using the name_outputs decorator; each peak class now has an attribute "input_t" and "output_t" which returns an ADT product type describing the input and output of `__call__.`

Removed the dedicated `_peak_isa_` which is included as a field in input_t