### PR TITLE
Mapper updates

### DIFF
--- a/examples/min_pe/isa.py
+++ b/examples/min_pe/isa.py
@@ -3,7 +3,7 @@ from hwtypes import new_instruction
 from functools import lru_cache
 
 @lru_cache(None)
-def gen_isa(family):
+def ISA_fc(family):
     Word = family.BitVector[8]
     Bit  = family.BitVector[1]
 

--- a/examples/min_pe/sim.py
+++ b/examples/min_pe/sim.py
@@ -1,8 +1,6 @@
 from .isa import ISA_fc
-from hwtypes import Product, Sum, Enum, Tuple
-from ast_tools.passes import begin_rewrite, end_rewrite
-from ast_tools.passes import ssa, bool_to_bit, if_to_phi
-from peak import Peak, name_outputs, family_closure
+from hwtypes import Product, Sum, Enum, Tuple, SMTBit
+from peak import Peak, name_outputs, family_closure, update_peak
 
 @family_closure
 def PE_fc(family):
@@ -10,11 +8,6 @@ def PE_fc(family):
     T = Tuple[Word, Bit]
     class PE(Peak):
 
-        @end_rewrite()
-        @if_to_phi(family.Bit.ite)
-        @bool_to_bit()
-        @ssa()
-        @begin_rewrite()
         @name_outputs(out=Word)
         def __call__(self, inst: Inst):
             o0 = inst.operand_0
@@ -36,4 +29,4 @@ def PE_fc(family):
                     res = o0 | o1
                 return b.ite(~res, res)
 
-    return PE
+    return update_peak(PE, family)

--- a/examples/min_pe/sim.py
+++ b/examples/min_pe/sim.py
@@ -1,13 +1,12 @@
-from .isa import gen_isa
+from .isa import ISA_fc
 from hwtypes import Product, Sum, Enum, Tuple
 from ast_tools.passes import begin_rewrite, end_rewrite
 from ast_tools.passes import ssa, bool_to_bit, if_to_phi
-from peak import Peak, name_outputs
-from functools import lru_cache
+from peak import Peak, name_outputs, family_closure
 
-@lru_cache(None)
-def gen_sim(family):
-    Word, Bit, Inst  = gen_isa(family)
+@family_closure
+def PE_fc(family):
+    Word, Bit, Inst  = ISA_fc(family)
     T = Tuple[Word, Bit]
     class PE(Peak):
 
@@ -37,4 +36,4 @@ def gen_sim(family):
                     res = o0 | o1
                 return b.ite(~res, res)
 
-    return Word, Bit, Inst, PE
+    return PE

--- a/peak/__init__.py
+++ b/peak/__init__.py
@@ -2,6 +2,6 @@
 from .register import gen_register
 from .memory import Memory, RAM, ROM
 
-from .peak import Peak, name_outputs, PeakNotImplementedError
+from .peak import Peak, name_outputs, PeakNotImplementedError, family_closure
 
 from .rtl_utils import wrap_with_disassembler

--- a/peak/__init__.py
+++ b/peak/__init__.py
@@ -2,6 +2,6 @@
 from .register import gen_register
 from .memory import Memory, RAM, ROM
 
-from .peak import Peak, name_outputs, PeakNotImplementedError, family_closure
+from .peak import Peak, name_outputs, PeakNotImplementedError, family_closure, update_peak
 
 from .rtl_utils import wrap_with_disassembler

--- a/peak/ir.py
+++ b/peak/ir.py
@@ -17,7 +17,7 @@ class IR:
             raise ValueError(f"{name} is already an existing instruction")
         self.instructions[name] = peak_fc
 
-    #fun should have the form def fun(family,*args)
+    #fun should have the form def fun(family, *args)
     def add_peak_instruction(self, name : str, input_interface : Product, output_interface : Product, fun : tp.Callable):
         #Assuming for now that abstract bitvectors are used in the interfaces
         inputs = input_interface.field_dict
@@ -25,17 +25,17 @@ class IR:
         tab = ' '*_TAB_SIZE
         t_to_tname = {}
         idx = 0
-        for t in it.chain(inputs.values(),outputs.values()):
+        for t in it.chain(inputs.values(), outputs.values()):
             if not t in t_to_tname:
                 t_to_tname[t] = f"t{idx}"
                 idx +=1
         class_src = [f"@_family_closure"]
         class_src.append(f"def peak_fc(family):")
-        for t,tname in t_to_tname.items():
+        for t, tname in t_to_tname.items():
             class_src.append(f"{tab*1}_{tname} = _rebind_type({tname}, family)")
         class_src.append(f"{tab*1}class {name}(Peak):")
-        output_types = ", ".join([f"{field} = _{t_to_tname[t]}" for field,t in outputs.items()])
-        input_types = ", ".join([f"{field} : _{t_to_tname[t]}" for field,t in inputs.items()])
+        output_types = ", ".join([f"{field} = _{t_to_tname[t]}" for field, t in outputs.items()])
+        input_types = ", ".join([f"{field} : _{t_to_tname[t]}" for field, t in inputs.items()])
         fun_call = "family, " + ", ".join(inputs.keys())
         class_src.append(f"{tab*2}@name_outputs({output_types})")
         class_src.append(f"{tab*2}def __call__(self, {input_types}):")
@@ -44,7 +44,7 @@ class IR:
         class_src = '\n'.join(class_src)
         exec_ls = {}
         #add all the types to globals
-        exec_gs = {tname:t for t,tname in t_to_tname.items()}
+        exec_gs = {tname:t for t, tname in t_to_tname.items()}
         exec_gs.update(dict(
             Peak=Peak,
             name_outputs=name_outputs,
@@ -52,7 +52,7 @@ class IR:
             _rebind_type=rebind_type,
             _family_closure=family_closure
         ))
-        exec(class_src,exec_gs,exec_ls)
+        exec(class_src, exec_gs, exec_ls)
         peak_fc = exec_ls["peak_fc"]
         self.add_instruction(name, peak_fc)
 

--- a/peak/ir.py
+++ b/peak/ir.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 import typing as tp
 from hwtypes.adt import Product
 from hwtypes import AbstractBitVector, AbstractBit, BitVector, Bit
-from .peak import Peak, name_outputs
+from .peak import Peak, name_outputs, family_closure
 import itertools as it
 from peak.mapper.utils import rebind_type
 
@@ -31,7 +31,8 @@ class IR:
             if not t in t_to_tname:
                 t_to_tname[t] = f"t{idx}"
                 idx +=1
-        class_src = f"def peak_fc(family):\n"
+        class_src = f"@_family_closure\n"
+        class_src += f"def peak_fc(family):\n"
         for t,tname in t_to_tname.items():
             class_src += f"{ts(1)}_{tname} = _rebind_type({tname}, family)\n"
         class_src += f"{ts(1)}class {name}(Peak):\n"
@@ -49,7 +50,8 @@ class IR:
             Peak=Peak,
             name_outputs=name_outputs,
             _fun_=fun,
-            _rebind_type=rebind_type
+            _rebind_type=rebind_type,
+            _family_closure=family_closure
         ))
         exec(class_src,exec_gs,exec_ls)
         peak_fc = exec_ls["peak_fc"]

--- a/peak/mapper/README.txt
+++ b/peak/mapper/README.txt
@@ -1,0 +1,109 @@
+The code that does the automatic mapping is rather complicated. This document is an attempt to define necessary terms in order to understand the codebase.
+
+Before describing how to create the single SMT formula, the following terms need to be defined:
+
+----------------ADT---------------
+This is an Algebraic Data Type that can be any of the following:
+  Product
+  Tuple
+  Sum
+  Enum
+  Bit/Bitvector
+
+It is important to think of an ADT type as a Tree data structure. Product/Tuple and Sum all contain some number of child ADT types whereas Enum/Bit/Bitvector are all the leaf nodes of the ADT tree 
+
+----------------Path---------------
+The term 'path' refers to a tuple describing the 'path' to a particular node in the adt tree in terms of product/tuple/sum fields. For example:
+
+class A(Product):
+    a=T0
+    b=T1
+class B(Product):
+    a=Sum[A,T2]
+    b=T3
+
+Here are the complete list of paths for B (and their corresponding types)
+   () -> B
+   ('a',) -> Sum[A,T2]
+   ('a', A) -> A
+   ('a', A, 'a') -> T0
+   ('a', A, 'b') -> T1
+   ('a', T2) -> T2
+   ('b',) -> Bit
+
+----------------Form---------------
+Any adt type has an isomorphic adt type which is in 'Sum of Products' form. The word 'Form' refers to one of the 'Products' of this SoP. Forms are uniquely deterined by each Sum decision of the original adt and contains only the leaf nodes from those decisions
+
+For example in the above ADT type B the following 2 forms are:
+
+Form 1:
+  sum choices: [('a',) -> A]
+  leaf nodes:
+     ('a', A, 'a') -> T0
+     ('a', A, 'b') -> T1
+     ('b',) -> Bit
+
+Form 2:
+  sum choices: [('a',) -> T]
+  leaf nodes:
+     ('a', T2) -> T2
+     ('b',) -> Bit
+
+---------------family closure----------------
+family closure (often abbreviated as 'fc') is a function that takes in one argument (the family) and returns a Peak class defined in terms of that family. These functions should always be cached.
+
+---------------input_t/output_t--------------
+The automatic mapper requires any peak class to annotate the names and types of all inputs and outputs. This is accomplished using the 'name_outputs' decorator on the __call__ method. This gives everyone access to the adt type which represents the input (input_t) and the adt type represenitng the output (output_t).
+
+For example:
+
+class PE(Peak):
+   @name_outputs(o1=T3,o2=T4)
+   def __call__(self, a=T1,b=T2):
+      ...
+
+PE.input_t would be equivelent to:
+
+class Input(Product):
+  a=T1
+  b=T2
+
+and PE.output_t would be equivelent to:
+class Output(Product):
+  o1=T3
+  o2=T4
+
+----------------ir/arch---------------
+The problem of automatic mapping is formulated between an ir primitve and an arch (isa) primitive which are both represented as a family_closure generating a peak class.
+
+Automatic mapping tries to solve the following problem: Given an aribtrary value of type ir.input_t (ir_input), how can you construct a value of type arch.input_t (arch_input) such that ir(ir_input) == arch(arch_input).
+
+Caveat: This is almost, but not quite correct given that the output types of the ir and the arch could be different. 
+
+
+----------------Binding---------------
+A Binding should be thought of as one possible way to match all the leaf nodes of ir.input_t to arch.input_t. More precisely, it is one way to match one form of ir.input_t to one form of arch.input_t
+
+A Binding is represented as a list of path pairs where one path is from the ir and one path is from the arch
+It is usually in the form tp.List[Tuple[ir_path, arch_path] with the caveat that 'ir_path' could be 'Unbound' or a constant value
+For example
+ class IRInput(Product):
+     a = Bit
+     b = BV[8]
+ class ArchInput(Product):
+     c = Bit
+     d = Bit
+     e = BV[8]
+
+ This has two valid bindings
+ 1:
+   ('a',)  <=> ('c',)
+   ('b',)  <=> ('e',)
+   Unbound <=> ('d',)
+ 2:
+   ('a',)  <=> ('d',)
+   ('b',)  <=> ('e',)
+   Unbound <=> ('c',)
+
+
+To be continued...

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -1,6 +1,6 @@
 import typing as tp
 import itertools as it
-from peak import Peak
+from peak import Peak, family_closure
 from hwtypes.adt import Product
 from hwtypes import SMTBit
 from hwtypes import SMTBitVector as SBV
@@ -14,6 +14,7 @@ from .utils import solved_to_bv, log2
 from .utils import smt_binding_to_bv_binding
 from .utils import pretty_print_binding
 
+
 import pysmt.shortcuts as smt
 from pysmt.logics import BV
 from collections import OrderedDict
@@ -26,7 +27,7 @@ and_reduce = partial(reduce, operator.and_)
 
 class SMTMapper:
     def __init__(self, peak_fc : tp.Callable):
-        if not (hasattr(peak_fc,"_is_fc") and peak_fc._is_fc):
+        if not isinstance(peak_fc, family_closure):
             raise ValueError(f"family closure {peak_fc} needs to be decorated with @family_closure")
         Peak_cls = peak_fc(SMTBit.get_family())
         input_t = Peak_cls.input_t
@@ -43,7 +44,7 @@ class SMTMapper:
 
             #Construct output_aadt value
             output = Peak_cls()(**inputs)
-            if isinstance(output,tuple):
+            if isinstance(output, tuple):
                 ofields = {field:output[i] for i, field in enumerate(output_aadt_t.adt_t.field_dict)}
             else:
                 ofields = {field:output for field in output_aadt_t.adt_t.field_dict}

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -45,9 +45,9 @@ class SMTMapper:
             output = Peak_cls()(**inputs)
             if isinstance(output,tuple):
                 ofields = {field:output[i] for i, field in enumerate(output_aadt_t.adt_t.field_dict)}
-                output = output_aadt_t.from_fields(**ofields)
             else:
-                output = output_aadt_t(output)
+                ofields = {field:output for field in output_aadt_t.adt_t.field_dict}
+            output = output_aadt_t.from_fields(**ofields)
 
             forms, output_varmap = SMTForms()(output_aadt_t, value=output)
             #Check consistency of SMTForms

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -12,6 +12,7 @@ from .utils import create_bindings
 from .utils import aadt_product_to_dict
 from .utils import solved_to_bv, log2
 from .utils import smt_binding_to_bv_binding
+from .utils import pretty_print_binding
 
 import pysmt.shortcuts as smt
 from pysmt.logics import BV
@@ -25,6 +26,8 @@ and_reduce = partial(reduce, operator.and_)
 
 class SMTMapper:
     def __init__(self, peak_fc : tp.Callable):
+        if not (hasattr(peak_fc,"_is_fc") and peak_fc._is_fc):
+            raise ValueError(f"family closure {peak_fc} needs to be decorated with @family_closure")
         Peak_cls = peak_fc(SMTBit.get_family())
         input_t = Peak_cls.input_t
         output_t = Peak_cls.output_t
@@ -37,8 +40,15 @@ class SMTMapper:
         output_forms = []
         for input_form in input_forms:
             inputs = aadt_product_to_dict(input_form.value)
+
+            #Construct output_aadt value
             output = Peak_cls()(**inputs)
-            output = output_aadt_t(output)
+            if isinstance(output,tuple):
+                ofields = {field:output[i] for i, field in enumerate(output_aadt_t.adt_t.field_dict)}
+                output = output_aadt_t.from_fields(**ofields)
+            else:
+                output = output_aadt_t(output)
+
             forms, output_varmap = SMTForms()(output_aadt_t, value=output)
             #Check consistency of SMTForms
             for f in forms:
@@ -86,7 +96,6 @@ class IRMapper(SMTMapper):
 
         #binding = [input_form_idx][bidx]
         input_bindings = [create_bindings(af.varmap, ir_input_form.varmap) for af in archmapper.input_forms]
-        assert input_bindings[0] != input_bindings[1]
 
         #binding = [bidx]
         output_bindings = create_bindings(archmapper.output_forms[0][0].varmap, ir_output_form.varmap)
@@ -129,6 +138,8 @@ class IRMapper(SMTMapper):
                     bo_match = (ob_var == 2**bo)
                     conditions = list(form_conditions[fi]) + [bi_match, bo_match]
                     for ir_path, arch_path in obinding:
+                        if ir_path is Unbound:
+                            continue
                         ir_out = self.output_forms[0][0].varmap[ir_path]
                         arch_out = archmapper.output_forms[fi][0].varmap[arch_path]
                         arch_out = arch_out.substitute(*submap)

--- a/peak/mapper/utils.py
+++ b/peak/mapper/utils.py
@@ -14,6 +14,9 @@ from hwtypes.adt_util import rebind_bitvector
 import pysmt.shortcuts as smt
 import typing as tp
 
+from ast_tools.passes import begin_rewrite, end_rewrite
+from ast_tools.passes import ssa, bool_to_bit, if_to_phi
+
 class Match: pass
 class Unbound: pass
 Form = namedtuple("Form", ["value", "path_dict", "varmap"])
@@ -345,4 +348,5 @@ def pretty_print_binding(binding):
     for ir_path, arch_path in binding:
         print(f"  {_pretty_path(ir_path)} <=> {_pretty_path(arch_path)}")
     print(")")
+
 

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -37,7 +37,7 @@ def name_outputs(**outputs):
             results = call_fn(*args, **kwargs)
             single_output = not isinstance(results, tuple)
             if single_output:
-                results = (results, )
+                results = (results,)
             for i, (oname, otype) in enumerate(outputs.items()):
                 if not isinstance(results[i], otype):
                     raise TypeError(f"result type for {oname} : {type(results[i])} did not match expected type {otype}")

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -6,7 +6,7 @@ from inspect import isclass
 from hwtypes import SMTBit
 from ast_tools.passes import begin_rewrite, end_rewrite
 from ast_tools.passes import ssa, bool_to_bit, if_to_phi
-
+import warnings
 
 
 class PeakMeta(type):
@@ -81,7 +81,7 @@ class family_closure:
 
         num_inputs = f.__code__.co_argcount
         if num_inputs != 1:
-            raise SyntaxError("Family Closure must take a single input 'family'")
+            warnings.warn("Family Closure should take a single input 'family'")
         functools.update_wrapper(self, f)
         self.cache = {}
 
@@ -90,7 +90,7 @@ class family_closure:
             return self.cache[family]
         cls = self.f(family)
         if not (isclass(cls) and issubclass(cls, Peak)):
-            raise SyntaxError("Family closure must return a peak class")
+            warnings.warn("Family closure should return a single Peak class")
         cls._fc_ = self
         self.cache[family] = cls
         return cls

--- a/tests/test_aadt_mapping.py
+++ b/tests/test_aadt_mapping.py
@@ -1,13 +1,13 @@
 from hwtypes import Bit, BitVector
 from peak.mapper.utils import pretty_print_binding
 from peak.mapper import ArchMapper
-from examples.min_pe.sim import gen_sim
+from examples.min_pe.sim import PE_fc
 from examples.smallir import gen_SmallIR
 
 num_test_vectors = 16
-def test_min_pe_auto():
+def test_automapper():
     IR = gen_SmallIR(8)
-    arch_fc = lambda f: gen_sim(f)[3]
+    arch_fc = PE_fc
     arch_bv = arch_fc(Bit.get_family())
     arch_mapper = ArchMapper(arch_fc)
     expect_found = ('Add', 'Sub', 'And', 'Nand', 'Or', 'Nor', 'Not', 'Neg')
@@ -29,5 +29,3 @@ def test_min_pe_auto():
             ir_inputs = solution.build_ir_input(ir_vals)
             arch_inputs = solution.build_arch_input(ir_vals)
             assert ir_bv()(**ir_inputs) == arch_bv()(**arch_inputs)
-
-test_min_pe_auto()

--- a/tests/test_assembled_adt.py
+++ b/tests/test_assembled_adt.py
@@ -4,7 +4,7 @@ from peak.assembler.assembler_util import _issubclass
 from examples.demo_pes.pe5.isa import INST as pe5_isa
 from examples.arm.isa import Inst as arm_isa
 from examples.pico.isa import Inst as pico_isa
-from examples.min_pe.isa import gen_isa as gen_min_isa
+from examples.min_pe.isa import ISA_fc as gen_min_isa
 import examples.pico.asm as pico_asm
 
 from hwtypes import BitVector, Bit

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -2,7 +2,7 @@ from peak.assembler.assembler import Assembler
 from examples.demo_pes.pe5.isa import INST as pe5_isa
 from examples.arm.isa import Inst as arm_isa
 from examples.pico.isa import Inst as pico_isa
-from examples.min_pe.isa import gen_isa as gen_min_isa
+from examples.min_pe.isa import ISA_fc as gen_min_isa
 from hwtypes import AbstractBitVector
 from hwtypes.adt import Enum, Product, Tuple, Sum
 from hwtypes.adt import new_instruction

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -25,7 +25,7 @@ def test_assembler_disassembler(isa, bv_type):
         assert isinstance(opcode, bv_type[assembler.width])
         assert assembler.disassemble(opcode) == inst
 
-        for name,field in isa.field_dict.items():
+        for name, field in isa.field_dict.items():
             sub_assembler = Assembler(field)
             if issubclass(isa, Sum):
                 assert assembler.sub[field].asm is sub_assembler

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -7,58 +7,58 @@ import pytest
 def test_inputs():
     #Expected inputs
     expected_names = ["inst", "data0", "data1", "bit0", "bit1", "bit2", "clk_en"]
-    expected_types = [Inst,Data,Data,Bit,Bit,Bit,Bit]
+    expected_types = [Inst, Data, Data, Bit, Bit, Bit, Bit]
 
     input_t = PE.input_t
     assert issubclass(input_t, Product)
-    for i, (iname,itype) in enumerate(input_t.field_dict.items()):
+    for i, (iname, itype) in enumerate(input_t.field_dict.items()):
         assert iname == expected_names[i]
         assert itype == expected_types[i]
 
 def test_outputs():
     #Expected inputs
     expected_names = ["alu_res", "res_p", "irq"]
-    expected_types = [Data,Bit,Bit]
+    expected_types = [Data, Bit, Bit]
 
     output_t = PE.output_t
     assert issubclass(output_t, Product)
-    for i, (oname,otype) in enumerate(output_t.field_dict.items()):
+    for i, (oname, otype) in enumerate(output_t.field_dict.items()):
         assert oname == expected_names[i]
         assert otype == expected_types[i]
 
 def test_family_closure():
     #family_closure needs single argument
-    with pytest.raises(ValueError):
+    with pytest.raises(SyntaxError):
         @family_closure
-        def fc(family,otherarg):
+        def fc(family, otherarg):
             class A(Peak): pass
             return A
 
     #family_closure needs to return a peak class
-    with pytest.raises(ValueError):
+    with pytest.raises(SyntaxError):
         @family_closure
         def fc(family):
             return 5
         cls = fc(Bit.get_family())
 
     #family_closure needs to return only a peak class
-    with pytest.raises(ValueError):
+    with pytest.raises(SyntaxError):
         @family_closure
         def fc(family):
             class A(Peak): pass
             return A, 5
-        cls,val = fc(Bit.get_family())
+        cls, val = fc(Bit.get_family())
 
     @family_closure
     def PE_fc(family):
         Word = family.BitVector[16]
         class PE(Peak):
             @name_outputs(out=Word)
-            def __call__(self,in0:Word,in1:Word):
+            def __call__(self, in0:Word, in1:Word):
                 return in0 + in1
         return PE
 
-    assert hasattr(PE_fc,"_is_fc") and PE_fc._is_fc is True
+    assert isinstance(PE_fc, family_closure)
 
     for family in (BitVector.get_family(), SMTBitVector.get_family()):
         #Test caching

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -27,27 +27,6 @@ def test_outputs():
         assert otype == expected_types[i]
 
 def test_family_closure():
-    #family_closure needs single argument
-    with pytest.raises(SyntaxError):
-        @family_closure
-        def fc(family, otherarg):
-            class A(Peak): pass
-            return A
-
-    #family_closure needs to return a peak class
-    with pytest.raises(SyntaxError):
-        @family_closure
-        def fc(family):
-            return 5
-        cls = fc(Bit.get_family())
-
-    #family_closure needs to return only a peak class
-    with pytest.raises(SyntaxError):
-        @family_closure
-        def fc(family):
-            class A(Peak): pass
-            return A, 5
-        cls, val = fc(Bit.get_family())
 
     @family_closure
     def PE_fc(family):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,5 +1,8 @@
 from examples.pe1 import PE, Inst, Bit, Data
 from hwtypes.adt import Product
+from hwtypes import BitVector, SMTBitVector
+from peak import Peak, name_outputs, family_closure
+import pytest
 
 def test_inputs():
     #Expected inputs
@@ -23,3 +26,43 @@ def test_outputs():
         assert oname == expected_names[i]
         assert otype == expected_types[i]
 
+def test_family_closure():
+    #family_closure needs single argument
+    with pytest.raises(ValueError):
+        @family_closure
+        def fc(family,otherarg):
+            class A(Peak): pass
+            return A
+
+    #family_closure needs to return a peak class
+    with pytest.raises(ValueError):
+        @family_closure
+        def fc(family):
+            return 5
+        cls = fc(Bit.get_family())
+
+    #family_closure needs to return only a peak class
+    with pytest.raises(ValueError):
+        @family_closure
+        def fc(family):
+            class A(Peak): pass
+            return A, 5
+        cls,val = fc(Bit.get_family())
+
+    @family_closure
+    def PE_fc(family):
+        Word = family.BitVector[16]
+        class PE(Peak):
+            @name_outputs(out=Word)
+            def __call__(self,in0:Word,in1:Word):
+                return in0 + in1
+        return PE
+
+    assert hasattr(PE_fc,"_is_fc") and PE_fc._is_fc is True
+
+    for family in (BitVector.get_family(), SMTBitVector.get_family()):
+        #Test caching
+        assert PE_fc(family) is PE_fc(family)
+
+        #Test storing the family closure in the Peak class
+        assert PE_fc(family)._fc_ is PE_fc

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,3 +1,4 @@
+from peak import family_closure
 from peak.ir import IR
 from hwtypes import BitVector, Bit, UIntVector
 from hwtypes import AbstractBitVector as ABV
@@ -11,7 +12,7 @@ from random import randint
 from peak.mapper.utils import rebind_type
 
 def rand_value(width):
-    return randint(0,2**width-1)
+    return randint(0, 2**width-1)
 
 #from examples.simple_sum import gen_simple_sum
 #from peak.mapper import ArchMapper, binding_pretty_print, Unbound
@@ -29,13 +30,13 @@ def test_add_peak_instruction():
 
     ir = IR()
     def fun(family, a, b, c):
-        return c.ite(a,b),c
+        return c.ite(a, b), c
 
     ir.add_peak_instruction("Simple", Input, Output, fun)
 
     assert "Simple" in ir.instructions
     Simple_fc = ir.instructions["Simple"]
-    assert hasattr(Simple_fc,"_is_fc") and Simple_fc._is_fc
+    assert isinstance(Simple_fc, family_closure)
     Simple = Simple_fc(Bit.get_family())
     InputBV = rebind_type(Input, Bit.get_family())
     OutputBV = rebind_type(Output, Bit.get_family())
@@ -46,7 +47,7 @@ def test_add_peak_instruction():
 
     simple = Simple()
     BV16 = BitVector[16]
-    x,y = simple(BV16(5),BV16(6),Bit(1))
+    x, y = simple(BV16(5), BV16(6), Bit(1))
     assert x == BV16(5)
     assert y == Bit(1)
 
@@ -69,18 +70,18 @@ def test_smallir(family, args):
         ("Or",   lambda x, y: (x|y)),
         ("Nor",  lambda x, y: ~(x|y)),
         ("Mul",  lambda x, y: x*y),
-        ("Shftr",lambda x, y: x>>y),
-        ("Shftl",lambda x, y: x<<y),
+        ("Shftr", lambda x, y: x>>y),
+        ("Shftl", lambda x, y: x<<y),
         ("Not",  lambda x: ~x),
         ("Neg",  lambda x: -x),
     ):
         Instr_fc = ir.instructions[name]
         Instr = Instr_fc(family)
         instr = Instr()
-        if name in ("Not","Neg"):
+        if name in ("Not", "Neg"):
             gold = fun(args[0])
             ret = instr(args[0])
         else:
-            gold = fun(args[0],args[1])
-            ret = instr(args[0],args[1])
+            gold = fun(args[0], args[1])
+            ret = instr(args[0], args[1])
         assert gold == ret

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -35,6 +35,7 @@ def test_add_peak_instruction():
 
     assert "Simple" in ir.instructions
     Simple_fc = ir.instructions["Simple"]
+    assert hasattr(Simple_fc,"_is_fc") and Simple_fc._is_fc
     Simple = Simple_fc(Bit.get_family())
     InputBV = rebind_type(Input, Bit.get_family())
     OutputBV = rebind_type(Output, Bit.get_family())


### PR DESCRIPTION
depends on #110 

Added a family_closure decorator along with tests for it.
Fixed bug regarding constructing the output type if there is a tuple
Fixed IR and min_pe to use family_closure
Added 'update_peak' function as an easier API to apply the ast_tools passes.