### PR TITLE
Major peak style cleanup

### DIFF
--- a/examples/demo_pes/pe6/__init__.py
+++ b/examples/demo_pes/pe6/__init__.py
@@ -1,0 +1,1 @@
+from .sim import PE_fc

--- a/examples/demo_pes/pe6/alu.py
+++ b/examples/demo_pes/pe6/alu.py
@@ -1,0 +1,26 @@
+from .isa import Op_fc
+from peak import Peak, assemble, family_closure
+
+@family_closure
+def ALU_fc(family):
+    Bit = family.Bit
+    Data = family.BitVector[16]
+    SData = family.Signed[16]
+    Op = Op_fc(family)
+
+    @assemble(family, locals(), globals())
+    class ALU(Peak):
+        def __call__(self, inst : Op, data0 : Data, data1 : Data) -> Data:
+            data0, data1 = SData(data0), SData(data1)
+            if inst == Op.Add:
+                res = data0 + data1
+            elif inst == Op.And:
+                res = data0 & data1
+            elif inst == Op.Xor:
+                res = data0 ^ data1
+            else: #inst == Op.Shft:
+                res = data0.bvshl(data1)
+
+            return res
+
+    return ALU

--- a/examples/demo_pes/pe6/isa.py
+++ b/examples/demo_pes/pe6/isa.py
@@ -1,0 +1,12 @@
+from peak import Enum_fc
+from functools import lru_cache
+
+@lru_cache(None)
+def Op_fc(family):
+    Enum = Enum_fc(family)
+    class Op(Enum):
+        Add  = 1
+        And  = 2
+        Xor  = 4
+        Shft = 8
+    return Op

--- a/examples/demo_pes/pe6/sim.py
+++ b/examples/demo_pes/pe6/sim.py
@@ -1,0 +1,37 @@
+from .isa import Op_fc
+from .alu import ALU_fc
+from peak import Peak, assemble, family_closure, Product_fc
+
+from hwtypes import TypeFamily
+
+@family_closure
+def PE_fc(family : TypeFamily):
+    Bit = family.Bit
+    Product = Product_fc(family)
+    Op = Op_fc(family)
+    class Inst(Product):
+        op0=Op
+        op1=Op
+        choice=Bit
+
+    Bit = family.Bit
+    Data = family.BitVector[16]
+
+    ALU = ALU_fc(family)
+
+    @assemble(family, locals(), globals())
+    class PE(Peak):
+        def __init__(self):
+            self.alu0 : ALU = ALU()
+            self.alu1 : ALU = ALU()
+
+        def __call__(self, inst : Inst, data0 : Data, data1 : Data) -> Data:
+            data1 = self.alu1(inst.op1, data0, data1)
+            data0 = self.alu0(inst.op0, data0, data1)
+
+            if inst.choice:
+                return data1
+            else:
+                return data0
+
+    return PE, Inst

--- a/examples/min_pe/isa.py
+++ b/examples/min_pe/isa.py
@@ -1,5 +1,5 @@
-from hwtypes import Product, Sum, Enum, Tuple
 from hwtypes import new_instruction
+from hwtypes.adt import Product, Sum, Tuple, Enum
 from functools import lru_cache
 
 @lru_cache(None)

--- a/examples/min_pe/sim.py
+++ b/examples/min_pe/sim.py
@@ -1,15 +1,16 @@
 from .isa import ISA_fc
-from hwtypes import Product, Sum, Enum, Tuple, SMTBit
-from peak import Peak, name_outputs, family_closure, update_peak
+from peak import Peak, name_outputs, family_closure, assemble, Tuple_fc
 
 @family_closure
 def PE_fc(family):
     Word, Bit, Inst  = ISA_fc(family)
-    T = Tuple[Word, Bit]
+    T = Tuple_fc(family)[Word, Bit]
+
+    @assemble(family, locals(), globals())
     class PE(Peak):
 
         @name_outputs(out=Word)
-        def __call__(self, inst: Inst):
+        def __call__(self, inst: Inst) -> Word:
             o0 = inst.operand_0
             if inst.operand_1[Word].match:
                 # arith op
@@ -28,5 +29,5 @@ def PE_fc(family):
                 else:
                     res = o0 | o1
                 return b.ite(~res, res)
+    return PE
 
-    return update_peak(PE, family)

--- a/examples/pdp8/sim.py
+++ b/examples/pdp8/sim.py
@@ -7,7 +7,7 @@ ONE = Bit(1)
 MAX_MEMORY = 4096
 
 
-class PDP8(Peak):
+class PDP8(Peak, unsafe=True):
 
     def __init__(self, mem):
         family = Bit.get_family()
@@ -83,7 +83,6 @@ class PDP8(Peak):
                 if opr1.rar: # rotate right
                     acc = self.acc(0,0).concat(BitVector[1](self.lnk(0,0)))
                     res = acc.bvror(2 if opr1.twice else 1)
-                    print('rar', res)
                     self.acc(res[0:WIDTH], 1)
                     self.lnk(res[WIDTH], 1)
             elif opr.opr2.match:
@@ -175,4 +174,4 @@ class PDP8(Peak):
         return int(self.mem(Word(addr),0,0))
 
     def poke_mem(self, addr, value):
-        return int(self.mem(Word(addr),Word(value),wen=1))
+        return int(self.mem(Word(addr),Word(value),wen=Bit(1)))

--- a/examples/pdp8/sim.py
+++ b/examples/pdp8/sim.py
@@ -7,7 +7,7 @@ ONE = Bit(1)
 MAX_MEMORY = 4096
 
 
-class PDP8(Peak, unsafe=True):
+class PDP8(Peak):
 
     def __init__(self, mem):
         family = Bit.get_family()
@@ -18,7 +18,7 @@ class PDP8(Peak, unsafe=True):
         self.lnk = gen_register2(family, Bit, ZERO)()
         self.running = gen_register2(family,Bit,ONE)()
 
-    def __call__(self):
+    def __call__(self) -> None:
         if not self.is_running():
             return
         # phase 0

--- a/examples/pe/mode.py
+++ b/examples/pe/mode.py
@@ -13,14 +13,14 @@ class Mode(Enum):
 
 
 def gen_register_mode(family: TypeFamily, T, init=0):
-    class RegisterMode(Peak, unsafe=True):
+    class RegisterMode(Peak):
         def __init__(self):
             self.register: T = gen_register(T, init)(family)()
 
         def reset(self):
             self.register.reset()
 
-        def __call__(self, mode: Mode, const, value, clk_en: Bit):
+        def __call__(self, mode: Mode, const: T, value: T, clk_en: Bit) -> T:
             if mode == Mode.CONST:
                 self.register(value, False)
                 return const

--- a/examples/pe/mode.py
+++ b/examples/pe/mode.py
@@ -13,7 +13,7 @@ class Mode(Enum):
 
 
 def gen_register_mode(family: TypeFamily, T, init=0):
-    class RegisterMode(Peak):
+    class RegisterMode(Peak, unsafe=True):
         def __init__(self):
             self.register: T = gen_register(T, init)(family)()
 

--- a/examples/pe/sim.py
+++ b/examples/pe/sim.py
@@ -20,11 +20,11 @@ def gen_pe(num_inputs):
             self.bit2 = gen_register_mode(family, Bit)()
 
         def __call__(self, inst: Inst, \
-                        data, \
+                        data: Data, \
                         bit0: Bit = Bit(0), \
                         bit1: Bit = Bit(0), \
                         bit2: Bit = Bit(0), \
-                        clk_en: Bit = Bit(1)):
+                        clk_en: Bit = Bit(1)) -> (Data, Bit, Bit) :
 
             # LUT part of the instruction
             lutinst = inst.lut

--- a/examples/pe1/mode.py
+++ b/examples/pe1/mode.py
@@ -13,14 +13,14 @@ class Mode(Enum):
 
 
 def gen_register_mode(family: TypeFamily, T, init=0):
-    class RegisterMode(Peak, unsafe=True):
+    class RegisterMode(Peak):
         def __init__(self):
             self.register: T = gen_register(T, init)(family)()
 
         def reset(self):
             self.register.reset()
 
-        def __call__(self, mode: Mode, const, value, clk_en: Bit):
+        def __call__(self, mode: Mode, const: T, value: T, clk_en: Bit) -> T:
             if mode == Mode.CONST:
                 self.register(value, False)
                 return const

--- a/examples/pe1/mode.py
+++ b/examples/pe1/mode.py
@@ -13,7 +13,7 @@ class Mode(Enum):
 
 
 def gen_register_mode(family: TypeFamily, T, init=0):
-    class RegisterMode(Peak):
+    class RegisterMode(Peak, unsafe=True):
         def __init__(self):
             self.register: T = gen_register(T, init)(family)()
 

--- a/examples/pico/sim.py
+++ b/examples/pico/sim.py
@@ -64,7 +64,7 @@ def cond(code, Z, N, C, V):
     elif code == Cond.Always:
         return Bit(1)
 
-class Pico(Peak):
+class Pico(Peak, unsafe=True):
 
     def __init__(self, mem):
         family = Bit.get_family()

--- a/examples/pico/sim.py
+++ b/examples/pico/sim.py
@@ -64,7 +64,7 @@ def cond(code, Z, N, C, V):
     elif code == Cond.Always:
         return Bit(1)
 
-class Pico(Peak, unsafe=True):
+class Pico(Peak):
 
     def __init__(self, mem):
         family = Bit.get_family()
@@ -77,7 +77,7 @@ class Pico(Peak, unsafe=True):
         self.C = gen_register2(family, Bit, ZERO)()
         self.V = gen_register2(family, Bit, ZERO)()
 
-    def __call__(self):
+    def __call__(self) -> None:
         pc = self.PC(0, 0)
         inst = self.mem(pc)
 #        type, inst = inst.match()

--- a/peak/__init__.py
+++ b/peak/__init__.py
@@ -1,7 +1,10 @@
 from .register import gen_register, gen_register2
 from .memory import Memory, RAM, ROM
 
-from .peak import Peak, name_outputs, PeakNotImplementedError, family_closure, update_peak, Const
+from .peak import Peak, PeakNotImplementedError, name_outputs, family_closure, assemble, Const
+
+#This will be removed after Magma ADT types work properly
+from .peak import Enum_fc, Product_fc, Tuple_fc
 
 from .rtl_utils import wrap_with_disassembler
 

--- a/peak/__init__.py
+++ b/peak/__init__.py
@@ -1,10 +1,12 @@
 from .register import gen_register, gen_register2
 from .memory import Memory, RAM, ROM
 
-from .peak import Peak, PeakNotImplementedError, name_outputs, family_closure, assemble, Const
+from .peak import Peak, PeakNotImplementedError, Const
+
+from .features import name_outputs, gen_input_t, gen_output_t, typecheck, assemble, family_closure
 
 #This will be removed after Magma ADT types work properly
-from .peak import Enum_fc, Product_fc, Tuple_fc
+from .utils import Enum_fc, Product_fc, Tuple_fc
 
 from .rtl_utils import wrap_with_disassembler
 

--- a/peak/features.py
+++ b/peak/features.py
@@ -1,0 +1,141 @@
+from collections import OrderedDict
+from hwtypes.adt import Product, Tuple
+import functools
+from ast_tools.passes import begin_rewrite, end_rewrite
+from ast_tools.passes import ssa, bool_to_bit, if_to_phi
+from ast_tools.stack import SymbolTable
+from hwtypes import SMTBit
+from peak.assembler import Assembler
+import magma
+
+def name_outputs(**outputs):
+    """Decorator meant to apply to any function to specify output types
+    The output type will be stored in fn._peak_outputs__
+    The input type will be stored in fn._peak_inputs_
+    Will verify that all the inputs have type annotations
+    Will also verify that the outputs of running fn will have the correct number of bits
+    """
+    peak_outputs = OrderedDict()
+    for oname, otype in outputs.items():
+        peak_outputs[oname] = otype
+    output_t = Product.from_fields("Output", peak_outputs)
+    def decorator(call_fn):
+        call_fn._output_t = output_t
+        return call_fn
+    return decorator
+
+def gen_input_t(call_fn):
+    try:
+        input_t = call_fn._input_t
+    except:
+        #construct input_t
+        arg_offset = 1 if call_fn.__name__ == "__call__" else 0
+        peak_inputs = OrderedDict()
+        num_inputs = call_fn.__code__.co_argcount
+        input_names = call_fn.__code__.co_varnames[arg_offset:num_inputs]
+        in_types = call_fn.__annotations__
+        in_type_keys = set(in_types.keys())
+        # Remove return annotation if it exists
+        if "return" in in_type_keys:
+            in_type_keys.remove("return")
+        if set(input_names) != set(in_type_keys):
+            raise ValueError(f"Missing type annotations on inputs: {set(input_names)} != {set(in_type_keys)}")
+        for name in input_names:
+            input_type= in_types[name]
+            peak_inputs[name] = in_types[name]
+
+        #Just set input_t to None if there are no inputs
+        if len(peak_inputs) == 0:
+            input_t = None #Empty 
+        else:
+            input_t = Product.from_fields("Input", peak_inputs)
+
+    call_fn._input_t = input_t
+    return call_fn
+
+def gen_output_t(call_fn):
+    try:
+        output_t = call_fn._output_t
+    except:
+        try:
+            output_types = call_fn.__annotations__['return']
+        except KeyError:
+            raise ValueError(f"Missing output type annotations on __call__ {call_fn}")
+        except AttributeError:
+            raise ValueError(f"Missing definition for __call__ {call_fn}")
+        if output_types is None:
+            output_t = None
+        else:
+            if not isinstance(output_types, tuple):
+                output_types = (output_types,)
+            output_t = Tuple[output_types]
+    call_fn._output_t = output_t
+    return call_fn
+
+def typecheck(call_fn):
+    try:
+        output_t = call_fn._output_t
+    except AttributeError:
+        raise ValueError("Need to use gen_output_t")
+
+    @functools.wraps(call_fn)
+    def call_wrapper(*args, **kwargs):
+        results = call_fn(*args, **kwargs)
+        single_output = not isinstance(results, tuple)
+        if single_output:
+            results = (results,)
+        for i, (oname, otype) in enumerate(output_t.field_dict.items()):
+            if not isinstance(results[i], otype):
+                raise TypeError(f"result type for output {oname} : {type(results[i])} did not match expected type {otype} in {call_fn}")
+        if single_output:
+            results = results[0]
+        return results
+    return call_wrapper
+
+#This decorator does the following:
+#1) Caches the function call
+#2) Stores the family closure in Peak._fc_ if it can
+class family_closure:
+    def __init__(self, fc):
+        self.fc = fc
+        self.cache = {}
+
+    def __call__(self, family, *args, **kwargs):
+        key = (family, tuple(args), tuple(kwargs.items()))
+        if key in self.cache:
+            return self.cache[key]
+        res = self.fc(family, *args, **kwargs)
+        try:
+            res._fc_ = self
+        except AttributeError:
+            pass
+        self.cache[key] = res
+        return res
+
+# Decorator for Peak classes to enable magma compilation and SMT mapping
+def assemble(family, locals, globals, assembler=Assembler):
+    def decorator(peak_cls):
+        if family is SMTBit.get_family():
+            call = peak_cls.__call__
+            input_t = call._input_t
+            output_t = call._output_t
+            for dec in (
+                begin_rewrite(),
+                ssa(),
+                bool_to_bit(),
+                if_to_phi(family.Bit.ite),
+                end_rewrite()):
+                call = dec(call)
+            call._input_t = input_t
+            call._output_t = output_t
+            peak_cls.__call__ = call
+        elif family is magma.get_family():
+            #Weirdly need to inject m=mamga into globals
+            _globals = {**globals, "m":magma}
+            env = SymbolTable(locals, _globals)
+            peak_cls = magma.circuit.sequential(peak_cls, env=env)
+        return peak_cls
+    return decorator
+
+
+

--- a/peak/features.py
+++ b/peak/features.py
@@ -103,10 +103,6 @@ class family_closure:
         if key in self.cache:
             return self.cache[key]
         res = self.fc(family, *args, **kwargs)
-        try:
-            res._fc_ = self
-        except AttributeError:
-            pass
         self.cache[key] = res
         return res
 

--- a/peak/features.py
+++ b/peak/features.py
@@ -75,7 +75,7 @@ def gen_output_t(call_fn):
 def typecheck(call_fn):
     if not hasattr(call_fn, "_output_t"):
         raise ValueError("Need to use gen_output_t for typechecking")
-
+    output_t = call_fn._output_t
     @functools.wraps(call_fn)
     def call_wrapper(*args, **kwargs):
         results = call_fn(*args, **kwargs)

--- a/peak/ir.py
+++ b/peak/ir.py
@@ -2,7 +2,8 @@ from collections import namedtuple
 import typing as tp
 from hwtypes.adt import Product
 from hwtypes import AbstractBitVector, AbstractBit, BitVector, Bit
-from .peak import Peak, name_outputs, family_closure
+from .peak import Peak
+from .features import name_outputs, family_closure
 import itertools as it
 from hwtypes.adt_util import rebind_type
 

--- a/peak/memory.py
+++ b/peak/memory.py
@@ -2,7 +2,7 @@ from .peak import Peak
 from .register import gen_register2
 from hwtypes import BitVector
 
-class ROM(Peak, unsafe=True):
+class ROM(Peak, gen_input_t=False, gen_output_t=False):
     def __init__(self, type, n, mem, init=0):
         self.mem = []
         for i in range(n):
@@ -12,7 +12,7 @@ class ROM(Peak, unsafe=True):
     def __call__(self, addr):
         return self.mem[int(addr)](0, 0)
 
-class RAM(ROM, unsafe=True):
+class RAM(ROM, gen_input_t=False, gen_output_t=False):
     def __call__(self, addr, data, wen):
         return self.mem[int(addr)](data, wen)
 

--- a/peak/memory.py
+++ b/peak/memory.py
@@ -2,7 +2,7 @@ from .peak import Peak
 from .register import gen_register2
 from hwtypes import BitVector
 
-class ROM(Peak):
+class ROM(Peak, unsafe=True):
     def __init__(self, type, n, mem, init=0):
         self.mem = []
         for i in range(n):
@@ -12,7 +12,7 @@ class ROM(Peak):
     def __call__(self, addr):
         return self.mem[int(addr)](0, 0)
 
-class RAM(ROM):
+class RAM(ROM, unsafe=True):
     def __call__(self, addr, data, wen):
         return self.mem[int(addr)](data, wen)
 

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -1,115 +1,31 @@
-from collections import OrderedDict
-from hwtypes import TypeFamily, AbstractBitVector, AbstractBit, BitVector, Bit, is_adt_type
-from hwtypes.adt import Product, Tuple
-import functools
-from inspect import isclass
-from ast_tools.passes import begin_rewrite, end_rewrite
-from ast_tools.passes import ssa, bool_to_bit, if_to_phi
-from ast_tools.stack import SymbolTable
 from hwtypes import make_modifier
-from hwtypes import SMTBit
-from hwtypes.adt import Enum
-from hwtypes.adt_meta import EnumMeta, AttrSyntax, GetitemSyntax
-from peak.assembler import Assembler
-from peak.assembler.utils import assemble_values_in_func
-import inspect
-import magma
-import warnings
-
-
-def name_outputs(**outputs):
-    """Decorator meant to apply to any function to specify output types
-    The output type will be stored in fn._peak_outputs__
-    The input type will be stored in fn._peak_inputs_
-    Will verify that all the inputs have type annotations
-    Will also verify that the outputs of running fn will have the correct number of bits
-    """
-    peak_outputs = OrderedDict()
-    for oname, otype in outputs.items():
-        peak_outputs[oname] = otype
-    output_t = Product.from_fields("Output", peak_outputs)
-    def decorator(call_fn):
-        call_fn.output_t = output_t
-        return call_fn
-    return decorator
-
-#Will color warnings yellow
-def warn(msg):
-    return warnings.warn(f"\033[1;33m{msg}\nPeak compiler will not work correctly.\033[1;0m")
-
-def set_input_output(call_fn):
-    try:
-        output_t = call_fn.output_t
-    except:
-        try:
-            output_types = call_fn.__annotations__['return']
-        except KeyError:
-            warn(f"Missing output type annotations on __call__ {call_fn}")
-            return call_fn
-        except AttributeError:
-            warn(f"Missing definition for __call__ {call_fn}")
-            return call_fn
-        if output_types is None:
-            output_t = None
-        else:
-            if not isinstance(output_types, tuple):
-                output_types = (output_types,)
-            output_t = Tuple[output_types]
-
-    #construct input_t
-    arg_offset = 1 if call_fn.__name__ == "__call__" else 0
-    peak_inputs = OrderedDict()
-    num_inputs = call_fn.__code__.co_argcount
-    input_names = call_fn.__code__.co_varnames[arg_offset:num_inputs]
-    in_types = call_fn.__annotations__
-    in_type_keys = set(in_types.keys())
-    # Remove return annotation if it exists
-    if "return" in in_type_keys:
-        in_type_keys.remove("return")
-    if set(input_names) != set(in_type_keys):
-        warn(f"Missing type annotations on inputs: {set(input_names)} != {set(in_type_keys)}")
-        return call_fn
-
-    for name in input_names:
-        input_type= in_types[name]
-        peak_inputs[name] = in_types[name]
-    input_t = Product.from_fields("Input", peak_inputs)
-
-    @functools.wraps(call_fn)
-    def call_wrapper(*args, **kwargs):
-        results = call_fn(*args, **kwargs)
-        single_output = not isinstance(results, tuple)
-        if single_output:
-            results = (results,)
-        for i, (oname, otype) in enumerate(output_t.field_dict.items()):
-            if not isinstance(results[i], otype):
-                warn(f"result type for output {oname} : {type(results[i])} did not match expected type {otype} in {call_fn}")
-        if single_output:
-            results = results[0]
-        return results
-
-    call_wrapper.input_t = input_t
-    call_wrapper.output_t = output_t
-    return call_wrapper
+from .features import gen_input_t as _gen_input_t
+from .features import gen_output_t as _gen_output_t
+from .features import typecheck as _typecheck
 
 class PeakMeta(type):
     @property
     def input_t(cls):
-        #peak classes should always have input_t
-        assert hasattr(cls.__call__, 'input_t')
-        return cls.__call__.input_t
+        return cls.__call__._input_t
 
     @property
     def output_t(cls):
-        #peak classes should always have output_t
-        assert hasattr(cls.__call__, 'output_t')
-        return cls.__call__.output_t
+        return cls.__call__._output_t
 
-    def __new__(mcs, name, bases, attrs, unsafe=False, **kwargs):
+    def __new__(mcs, name, bases, attrs,
+            gen_input_t=True,
+            gen_output_t=True,
+            typecheck=False,
+            **kwargs):
         cls = super().__new__(mcs, name, bases, attrs, **kwargs)
-        if "__call__" in attrs and (not unsafe):
-            cls.__call__ = set_input_output(cls.__call__)
-            assert cls.__call__ is not None
+        if "__call__" in attrs:
+            if gen_output_t:
+                cls.__call__ = _gen_output_t(cls.__call__)
+            if gen_input_t:
+                cls.__call__ = _gen_input_t(cls.__call__)
+            if typecheck:
+                cls.__call__ = _typecheck(cls.__call__)
+
         return cls
 
 class Peak(metaclass=PeakMeta): pass
@@ -117,94 +33,4 @@ class Peak(metaclass=PeakMeta): pass
 class PeakNotImplementedError(NotImplementedError):
     pass
 
-
-
-#Helper function to search for the one peak class
-def get_Peak_cls(fc_out):
-    clss = []
-    if not isinstance(fc_out, tuple):
-        fc_out = (fc_out,)
-    for cls in fc_out:
-        if inspect.isclass(cls) and issubclass(cls, Peak):
-            clss.append(cls)
-    if len(clss) == 1:
-        return clss[0]
-    raise TypeError(f"Need to return one Peak class instead of {len(clss)} Peak classes: {fc_out}")
-
-
-#This decorator does the following:
-#1) Caches the function call
-#2) Stores the family closure in Peak._fc_
-class family_closure:
-    def __init__(self, fc):
-        self.fc = fc
-
-        num_inputs = fc.__code__.co_argcount
-        if num_inputs != 1:
-            warn("Family Closure should take a single input 'family'")
-        functools.update_wrapper(self, fc)
-        self.cache = {}
-
-    def __call__(self, family):
-        if family in self.cache:
-            return self.cache[family]
-        cls = self.fc(family)
-        try:
-            peak_cls = get_Peak_cls(cls)
-            peak_cls._fc_ = self
-        except TypeError as e:
-            if family is not magma.get_family():
-                warn(f"Family closure should return one Peak class, Instead {e}")
-        self.cache[family] = cls
-        return cls
-
-class PeakNotImplementedError(NotImplementedError):
-    pass
-
-# Decorator for Peak classes to enable magma compilation and SMT mapping
-def assemble(family, locals, globals, assembler=Assembler):
-    def decorator(peak_cls):
-        if family is SMTBit.get_family():
-            call = peak_cls.__call__
-            input_t = call.input_t
-            output_t = call.output_t
-            for dec in (
-                begin_rewrite(),
-                ssa(),
-                bool_to_bit(),
-                if_to_phi(family.Bit.ite),
-                end_rewrite()):
-                call = dec(call)
-            call.input_t = input_t
-            call.output_t = output_t
-            peak_cls.__call__ = call
-        elif family is magma.get_family():
-            #Weirdly need to inject m=mamga into globals
-            _globals = {**globals, "m":magma}
-            env = SymbolTable(locals, _globals)
-            peak_cls = magma.circuit.sequential(peak_cls, env=env)
-        return peak_cls
-    return decorator
-
-
 Const = make_modifier("Const")
-
-def Enum_fc(family):
-    if family is magma.get_family():
-        return magma.Enum
-    else:
-        return Enum
-
-def Product_fc(family):
-    if family is magma.get_family():
-        return magmaa.Product
-    else:
-        return Product
-
-def Tuple_fc(family):
-    if family is magma.get_family():
-        return magma.Tuple
-    else:
-        return Tuple
-
-

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -180,8 +180,8 @@ def assemble(family, locals, globals, assembler=Assembler):
             peak_cls.__call__ = call
         elif family is magma.get_family():
             #Weirdly need to inject m=mamga into globals
-            _globals = {**globals,"m":magma}
-            env = SymbolTable(locals,_globals)
+            _globals = {**globals, "m":magma}
+            env = SymbolTable(locals, _globals)
             peak_cls = magma.circuit.sequential(peak_cls, env=env)
         return peak_cls
     return decorator

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -1,29 +1,21 @@
 from collections import OrderedDict
 from hwtypes import TypeFamily, AbstractBitVector, AbstractBit, BitVector, Bit, is_adt_type
-from hwtypes.adt import Product
+from hwtypes.adt import Product, Tuple
 import functools
 from inspect import isclass
-from hwtypes import SMTBit
 from ast_tools.passes import begin_rewrite, end_rewrite
 from ast_tools.passes import ssa, bool_to_bit, if_to_phi
+from ast_tools.stack import SymbolTable
 from hwtypes import make_modifier
+from hwtypes import SMTBit
+from hwtypes.adt import Enum
+from hwtypes.adt_meta import EnumMeta, AttrSyntax, GetitemSyntax
+from peak.assembler import Assembler
+from peak.assembler.utils import assemble_values_in_func
+import inspect
+import magma
 import warnings
 
-
-class PeakMeta(type):
-    @property
-    def input_t(cls):
-        if not hasattr(cls.__call__, '_peak_inputs_'):
-            raise ValueError("Missing type annotations. Did you forget to decorate __call__ with 'name_outputs'")
-        return cls.__call__._peak_inputs_
-
-    @property
-    def output_t(cls):
-        if not hasattr(cls.__call__, '_peak_outputs_'):
-            raise ValueError("Missing type annotations. Did you forget to decorate __call__ with 'name_outputs'")
-        return cls.__call__._peak_outputs_
-
-class Peak(metaclass=PeakMeta): pass
 
 def name_outputs(**outputs):
     """Decorator meant to apply to any function to specify output types
@@ -32,88 +24,187 @@ def name_outputs(**outputs):
     Will verify that all the inputs have type annotations
     Will also verify that the outputs of running fn will have the correct number of bits
     """
+    peak_outputs = OrderedDict()
+    for oname, otype in outputs.items():
+        peak_outputs[oname] = otype
+    output_t = Product.from_fields("Output", peak_outputs)
     def decorator(call_fn):
-        @functools.wraps(call_fn)
-        def call_wrapper(*args, **kwargs):
-            results = call_fn(*args, **kwargs)
-            single_output = not isinstance(results, tuple)
-            if single_output:
-                results = (results,)
-            for i, (oname, otype) in enumerate(outputs.items()):
-                if not isinstance(results[i], otype):
-                    raise TypeError(f"result type for {oname} : {type(results[i])} did not match expected type {otype}")
-            if single_output:
-                results = results[0]
-            return results
-
-        #Set all the outputs
-        peak_outputs = OrderedDict()
-        for oname, otype in outputs.items():
-            if not issubclass(otype, (AbstractBitVector, AbstractBit)):
-                raise TypeError(f"{oname} is not a Bitvector class")
-            peak_outputs[oname] = otype
-        call_wrapper._peak_outputs_ = Product.from_fields("Output", peak_outputs)
-
-        #set all the inputs
-        arg_offset = 1 if call_fn.__name__ == "__call__" else 0
-        peak_inputs = OrderedDict()
-        num_inputs = call_fn.__code__.co_argcount
-        input_names = call_fn.__code__.co_varnames[arg_offset:num_inputs]
-        in_types = call_fn.__annotations__
-        in_type_keys = set(in_types.keys())
-        # Remove return annotation if it exists
-        if "return" in in_type_keys:
-            in_type_keys.remove("return")
-        if set(input_names) != set(in_type_keys):
-            raise TypeError(f"Missing type annotations on inputs: {set(input_names)} != {set(in_type_keys)}")
-        for name in input_names:
-            input_type= in_types[name]
-            peak_inputs[name] = in_types[name]
-        call_wrapper._peak_inputs_ = Product.from_fields("Input", peak_inputs)
-        return call_wrapper
+        call_fn.output_t = output_t
+        return call_fn
     return decorator
+
+#Will color warnings yellow
+def warn(msg):
+    return warnings.warn(f"\033[1;33m{msg}\nPeak compiler will not work correctly.\033[1;0m")
+
+def set_input_output(call_fn):
+    try:
+        output_t = call_fn.output_t
+    except:
+        try:
+            output_types = call_fn.__annotations__['return']
+        except KeyError:
+            warn(f"Missing output type annotations on __call__ {call_fn}")
+            return call_fn
+        except AttributeError:
+            warn(f"Missing definition for __call__ {call_fn}")
+            return call_fn
+        if output_types is None:
+            output_t = None
+        else:
+            if not isinstance(output_types, tuple):
+                output_types = (output_types,)
+            output_t = Tuple[output_types]
+
+    #construct input_t
+    arg_offset = 1 if call_fn.__name__ == "__call__" else 0
+    peak_inputs = OrderedDict()
+    num_inputs = call_fn.__code__.co_argcount
+    input_names = call_fn.__code__.co_varnames[arg_offset:num_inputs]
+    in_types = call_fn.__annotations__
+    in_type_keys = set(in_types.keys())
+    # Remove return annotation if it exists
+    if "return" in in_type_keys:
+        in_type_keys.remove("return")
+    if set(input_names) != set(in_type_keys):
+        warn(f"Missing type annotations on inputs: {set(input_names)} != {set(in_type_keys)}")
+        return call_fn
+
+    for name in input_names:
+        input_type= in_types[name]
+        peak_inputs[name] = in_types[name]
+    input_t = Product.from_fields("Input", peak_inputs)
+
+    @functools.wraps(call_fn)
+    def call_wrapper(*args, **kwargs):
+        results = call_fn(*args, **kwargs)
+        single_output = not isinstance(results, tuple)
+        if single_output:
+            results = (results,)
+        for i, (oname, otype) in enumerate(output_t.field_dict.items()):
+            if not isinstance(results[i], otype):
+                warn(f"result type for output {oname} : {type(results[i])} did not match expected type {otype} in {call_fn}")
+        if single_output:
+            results = results[0]
+        return results
+
+    call_wrapper.input_t = input_t
+    call_wrapper.output_t = output_t
+    return call_wrapper
+
+class PeakMeta(type):
+    @property
+    def input_t(cls):
+        #peak classes should always have input_t
+        assert hasattr(cls.__call__, 'input_t')
+        return cls.__call__.input_t
+
+    @property
+    def output_t(cls):
+        #peak classes should always have output_t
+        assert hasattr(cls.__call__, 'output_t')
+        return cls.__call__.output_t
+
+    def __new__(mcs, name, bases, attrs, unsafe=False, **kwargs):
+        cls = super().__new__(mcs, name, bases, attrs, **kwargs)
+        if "__call__" in attrs and (not unsafe):
+            cls.__call__ = set_input_output(cls.__call__)
+            assert cls.__call__ is not None
+        return cls
+
+class Peak(metaclass=PeakMeta): pass
+
+class PeakNotImplementedError(NotImplementedError):
+    pass
+
+
+
+#Helper function to search for the one peak class
+def get_Peak_cls(fc_out):
+    clss = []
+    if not isinstance(fc_out, tuple):
+        fc_out = (fc_out,)
+    for cls in fc_out:
+        if inspect.isclass(cls) and issubclass(cls, Peak):
+            clss.append(cls)
+    if len(clss) == 1:
+        return clss[0]
+    raise TypeError(f"Need to return one Peak class instead of {len(clss)} Peak classes: {fc_out}")
+
 
 #This decorator does the following:
 #1) Caches the function call
 #2) Stores the family closure in Peak._fc_
 class family_closure:
-    def __init__(self, f):
-        self.f = f
+    def __init__(self, fc):
+        self.fc = fc
 
-        num_inputs = f.__code__.co_argcount
+        num_inputs = fc.__code__.co_argcount
         if num_inputs != 1:
-            warnings.warn("Family Closure should take a single input 'family'")
-        functools.update_wrapper(self, f)
+            warn("Family Closure should take a single input 'family'")
+        functools.update_wrapper(self, fc)
         self.cache = {}
 
     def __call__(self, family):
         if family in self.cache:
             return self.cache[family]
-        cls = self.f(family)
-        if not (isclass(cls) and issubclass(cls, Peak)):
-            warnings.warn("Family closure should return a single Peak class")
-        else:
-            cls._fc_ = self
+        cls = self.fc(family)
+        try:
+            peak_cls = get_Peak_cls(cls)
+            peak_cls._fc_ = self
+        except TypeError as e:
+            if family is not magma.get_family():
+                warn(f"Family closure should return one Peak class, Instead {e}")
         self.cache[family] = cls
         return cls
 
 class PeakNotImplementedError(NotImplementedError):
     pass
 
-#This will update the call function of peak appropriately for automapping
-#Needs to be called from within the family_closure function
-def update_peak(peak_cls, family):
-    if family is SMTBit.get_family():
-        call = peak_cls.__call__
-        for dec in (
-            begin_rewrite(),
-            ssa(),
-            bool_to_bit(),
-            if_to_phi(family.Bit.ite),
-            end_rewrite()):
-            call = dec(call)
-        peak_cls.__call__ = call
-    return peak_cls
+# Decorator for Peak classes to enable magma compilation and SMT mapping
+def assemble(family, locals, globals, assembler=Assembler):
+    def decorator(peak_cls):
+        if family is SMTBit.get_family():
+            call = peak_cls.__call__
+            input_t = call.input_t
+            output_t = call.output_t
+            for dec in (
+                begin_rewrite(),
+                ssa(),
+                bool_to_bit(),
+                if_to_phi(family.Bit.ite),
+                end_rewrite()):
+                call = dec(call)
+            call.input_t = input_t
+            call.output_t = output_t
+            peak_cls.__call__ = call
+        elif family is magma.get_family():
+            #Weirdly need to inject m=mamga into globals
+            _globals = {**globals,"m":magma}
+            env = SymbolTable(locals,_globals)
+            peak_cls = magma.circuit.sequential(peak_cls, env=env)
+        return peak_cls
+    return decorator
 
 
 Const = make_modifier("Const")
+
+def Enum_fc(family):
+    if family is magma.get_family():
+        return magma.Enum
+    else:
+        return Enum
+
+def Product_fc(family):
+    if family is magma.get_family():
+        return magmaa.Product
+    else:
+        return Product
+
+def Tuple_fc(family):
+    if family is magma.get_family():
+        return magma.Tuple
+    else:
+        return Tuple
+
+

--- a/peak/register.py
+++ b/peak/register.py
@@ -1,4 +1,4 @@
-from .peak import Peak, family_closure, name_outputs, update_peak
+from .peak import Peak, assemble, family_closure, name_outputs
 from hwtypes import BitVector
 import magma as m
 from hwtypes.adt_util import rebind_type
@@ -9,6 +9,7 @@ def gen_register(T, init=0):
         T_f = rebind_type(T, family)
         init_f = T_f(init)
 
+        @assemble(family, locals(), globals())
         class Register(Peak):
             def __init__(self):
                 self.value: T_f = init_f
@@ -19,29 +20,31 @@ def gen_register(T, init=0):
                 if en:
                     self.value = value
                 else:
-                    # Bug in magma sequential syntax without default values, we
-                    # explicitly set it for now
                     self.value = self.value
                 return retvalue
-        if family.Bit is m.Bit:
-            Register = m.circuit.sequential(Register)
-        return update_peak(Register, family)
+
+            def read(self) -> T_f:
+                return self.value
+
+            def write(self, val : T_f):
+                self.value = val
+        return Register
+
     return Register_fc
 
 #Old inteface to gen_register
 def gen_register2(family, T, init=0):
-    class Register(Peak):
+    Bit = family.Bit
+    class Register(Peak, unsafe=True):
         def __init__(self):
             self.value: T = init
 
-        def __call__(self, value: T, en: family.Bit) -> T:
+        def __call__(self, value : T, en : Bit) -> T:
             assert value is not None
             retvalue = self.value
             if en:
                 self.value = value
             else:
-                # Bug in magma sequential syntax without default values, we
-                # explicitly set it for now
                 self.value = self.value
             return retvalue
 

--- a/peak/register.py
+++ b/peak/register.py
@@ -1,4 +1,5 @@
-from .peak import Peak, assemble, family_closure, name_outputs
+from .peak import Peak
+from .features import assemble, family_closure, name_outputs
 from hwtypes import BitVector
 import magma as m
 from hwtypes.adt_util import rebind_type
@@ -35,7 +36,7 @@ def gen_register(T, init=0):
 #Old inteface to gen_register
 def gen_register2(family, T, init=0):
     Bit = family.Bit
-    class Register(Peak, unsafe=True):
+    class Register(Peak):
         def __init__(self):
             self.value: T = init
 

--- a/peak/utils.py
+++ b/peak/utils.py
@@ -1,0 +1,21 @@
+import magma
+from hwtypes import Enum, Product, Tuple
+
+def Enum_fc(family):
+    if family is magma.get_family():
+        return magma.Enum
+    else:
+        return Enum
+
+def Product_fc(family):
+    if family is magma.get_family():
+        return magma.Product
+    else:
+        return Product
+
+def Tuple_fc(family):
+    if family is magma.get_family():
+        return magma.Tuple
+    else:
+        return Tuple
+

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -53,7 +53,7 @@ def test_family_closure():
     with pytest.warns(None) as record:
         @family_closure
         def fc(family):
-            S = Sum[int,str]
+            S = Sum[int, str]
             class A(Peak): pass
             return A, S
         cls, _ = fc(Bit.get_family())

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -38,5 +38,4 @@ def test_family_closure():
         return PE
 
     assert isinstance(PE_fc, family_closure)
-    assert PE_fc(Bit.get_family())._fc_ is PE_fc
     assert PE_fc(Bit.get_family()) is PE_fc(Bit.get_family())

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -27,37 +27,6 @@ def test_outputs():
         assert otype == expected_types[i]
 
 def test_family_closure():
-    #family_closure needs single argument
-    with pytest.warns(Warning):
-        @family_closure
-        def fc(family, otherarg):
-            class A(Peak): pass
-            return A
-
-    #family_closure needs to return a peak class
-    with pytest.warns(Warning):
-        @family_closure
-        def fc(family):
-            return 5
-        cls = fc(Bit.get_family())
-
-    #family_closure needs to return only a single peak class
-    with pytest.warns(Warning):
-        @family_closure
-        def fc(family):
-            class A(Peak): pass
-            return A, A
-        cls, _ = fc(Bit.get_family())
-
-    #family closure can return other objects, as long as there is only one peak class
-    with pytest.warns(None) as record:
-        @family_closure
-        def fc(family):
-            S = Sum[int, str]
-            class A(Peak): pass
-            return A, S
-        cls, _ = fc(Bit.get_family())
-    assert len(record)==0
 
     @family_closure
     def PE_fc(family):
@@ -69,24 +38,5 @@ def test_family_closure():
         return PE
 
     assert isinstance(PE_fc, family_closure)
-
-    for family in (BitVector.get_family(), SMTBitVector.get_family()):
-        #Test caching
-        assert PE_fc(family) is PE_fc(family)
-
-        #Test storing the family closure in the Peak class
-        assert PE_fc(family)._fc_ is PE_fc
-
-def test_unsafe():
-    def fc(family):
-        class A(Peak, unsafe=True):
-            def __call__(self, val):
-                return val
-    with pytest.warns(None) as record:
-        fc(Bit.get_family())
-    assert len(record) == 0
-
-
-
-
-
+    assert PE_fc(Bit.get_family())._fc_ is PE_fc
+    assert PE_fc(Bit.get_family()) is PE_fc(Bit.get_family())

--- a/tests/test_magma.py
+++ b/tests/test_magma.py
@@ -20,21 +20,21 @@ def test_assemble():
     #verify BV works
     PE_bv = PE_fc(Bit.get_family())
     vals = [Bit(0), Bit(1)]
-    for i0,i1 in itertools.product(vals,vals):
+    for i0, i1 in itertools.product(vals, vals):
         assert PE_bv()(i0, i1) == i0 & i1
 
     #verify SMT works
     PE_smt = PE_fc(SMTBit.get_family())
     vals = [SMTBit(0), SMTBit(1), SMTBit(), SMTBit()]
-    for i0,i1 in itertools.product(vals,vals):
+    for i0, i1 in itertools.product(vals, vals):
         assert PE_smt()(i0, i1) == i0 & i1
 
     #verify magma works
     PE_magma = PE_fc(magma.get_family())
     print(PE_magma)
     tester = fault.Tester(PE_magma)
-    vals = [0,1]
-    for i0, i1 in itertools.product(vals,vals):
+    vals = [0, 1]
+    for i0, i1 in itertools.product(vals, vals):
         tester.circuit.in0 = i0
         tester.circuit.in1 = i1
         tester.eval()
@@ -71,7 +71,7 @@ def test_enum():
     PE_bv, Op = PE_fc(Bit.get_family())
     vals = [Bit(0), Bit(1)]
     for op in Op.enumerate():
-        for i0,i1 in itertools.product(vals,vals):
+        for i0, i1 in itertools.product(vals, vals):
             res = PE_bv()(op, i0, i1)
             gold = (i0 & i1 ) if (op is Op.And) else (i0 | i1)
             assert res == gold
@@ -82,7 +82,7 @@ def test_enum():
     vals = [SMTBit(0), SMTBit(1), SMTBit(), SMTBit()]
     for op in Op.enumerate():
         op = Op_aadt(op)
-        for i0,i1 in itertools.product(vals,vals):
+        for i0, i1 in itertools.product(vals, vals):
             res = PE_smt()(op, i0, i1)
             gold = (i0 & i1 ) if (op is Op.And) else (i0 | i1)
             assert res == gold
@@ -90,9 +90,9 @@ def test_enum():
     # verify magma works
     PE_magma, Op = PE_fc(magma.get_family())
     tester = fault.Tester(PE_magma)
-    vals = [0,1]
+    vals = [0, 1]
     for op in (Op.And, Op.Or):
-        for i0, i1 in itertools.product(vals,vals):
+        for i0, i1 in itertools.product(vals, vals):
             gold = (i0 & i1 ) if (op is Op.And) else (i0 | i1)
             tester.circuit.op = int(op)
             tester.circuit.in0 = i0

--- a/tests/test_magma.py
+++ b/tests/test_magma.py
@@ -1,0 +1,105 @@
+from peak import Peak, family_closure, assemble, Enum_fc
+from peak.assembler import Assembler, AssembledADT
+from hwtypes import Bit, SMTBit, SMTBitVector
+import fault
+import magma
+import itertools
+
+def test_assemble():
+    @family_closure
+    def PE_fc(family):
+        Bit = family.Bit
+
+        @assemble(family, locals(), globals())
+        class PE(Peak):
+            def __call__(self, in0: Bit, in1: Bit) -> Bit:
+                return in0 & in1
+
+        return PE
+
+    #verify BV works
+    PE_bv = PE_fc(Bit.get_family())
+    vals = [Bit(0), Bit(1)]
+    for i0,i1 in itertools.product(vals,vals):
+        assert PE_bv()(i0, i1) == i0 & i1
+
+    #verify SMT works
+    PE_smt = PE_fc(SMTBit.get_family())
+    vals = [SMTBit(0), SMTBit(1), SMTBit(), SMTBit()]
+    for i0,i1 in itertools.product(vals,vals):
+        assert PE_smt()(i0, i1) == i0 & i1
+
+    #verify magma works
+    PE_magma = PE_fc(magma.get_family())
+    print(PE_magma)
+    tester = fault.Tester(PE_magma)
+    vals = [0,1]
+    for i0, i1 in itertools.product(vals,vals):
+        tester.circuit.in0 = i0
+        tester.circuit.in1 = i1
+        tester.eval()
+        tester.circuit.O.expect(i0 & i1)
+    tester.compile_and_run("verilator", flags=["-Wno-fatal"])
+
+
+def test_enum():
+
+    def Op_fc(family):
+        Enum = Enum_fc(family)
+        class Op(Enum):
+            And=1
+            Or=2
+        return Op
+
+    @family_closure
+    def PE_fc(family):
+
+        Bit = family.Bit
+        Op = Op_fc(family)
+
+        @assemble(family, locals(), globals())
+        class PE_Enum(Peak):
+            def __call__(self, op: Op, in0: Bit, in1: Bit) -> Bit:
+                if op == Op.And:
+                    return in0 & in1
+                else: #op == Op.Or
+                    return in0 | in1
+
+        return PE_Enum, Op
+
+    # verify BV works
+    PE_bv, Op = PE_fc(Bit.get_family())
+    vals = [Bit(0), Bit(1)]
+    for op in Op.enumerate():
+        for i0,i1 in itertools.product(vals,vals):
+            res = PE_bv()(op, i0, i1)
+            gold = (i0 & i1 ) if (op is Op.And) else (i0 | i1)
+            assert res == gold
+
+    # verify BV works
+    PE_smt, Op = PE_fc(SMTBit.get_family())
+    Op_aadt = AssembledADT[Op, Assembler, SMTBitVector]
+    vals = [SMTBit(0), SMTBit(1), SMTBit(), SMTBit()]
+    for op in Op.enumerate():
+        op = Op_aadt(op)
+        for i0,i1 in itertools.product(vals,vals):
+            res = PE_smt()(op, i0, i1)
+            gold = (i0 & i1 ) if (op is Op.And) else (i0 | i1)
+            assert res == gold
+
+    # verify magma works
+    PE_magma, Op = PE_fc(magma.get_family())
+    tester = fault.Tester(PE_magma)
+    vals = [0,1]
+    for op in (Op.And, Op.Or):
+        for i0, i1 in itertools.product(vals,vals):
+            gold = (i0 & i1 ) if (op is Op.And) else (i0 | i1)
+            tester.circuit.op = int(op)
+            tester.circuit.in0 = i0
+            tester.circuit.in1 = i1
+            tester.eval()
+            tester.circuit.O.expect(gold)
+    tester.compile_and_run("verilator", flags=["-Wno-fatal"])
+
+
+


### PR DESCRIPTION
Presents a single clean style for compiling to Magma, and creating SMT formulas for mapping bu using an `assemble() `decorator. This can be seen in tests/test_magma.py

Other Changes:
-defines Enum_fc. Product_fc, Tuple_fc as a workaround for `m.Product != hwtypes.adt.Product`
-Moves logic of name_outputs (namely creating input and output types) into PeakMeta enabling output annotations for automapper
-modularizes features like gen_input_t and gen_output_t and typecheck