### PR TITLE
Map const

### DIFF
--- a/examples/sum_pe/isa.py
+++ b/examples/sum_pe/isa.py
@@ -1,0 +1,18 @@
+from hwtypes import new_instruction
+from hwtypes.adt import Product, Sum, Tuple, Enum
+from functools import lru_cache
+from peak import Const
+
+@lru_cache(None)
+def ISA_fc(family):
+    Word = family.BitVector[8]
+    Bit  = family.BitVector[1]
+
+    Operand0T = Word
+    Operand1T = Sum[Word, Tuple[Word, Bit]]
+    class Inst(Product):
+        class Opcode(Enum):
+            A  = 1
+            B  = 2
+        offset = Word
+    return Inst, Operand0T, Operand1T, Word, Tuple[Word, Bit]

--- a/examples/sum_pe/sim.py
+++ b/examples/sum_pe/sim.py
@@ -1,0 +1,35 @@
+from hwtypes import Tuple
+
+from .isa import ISA_fc
+from peak import Peak, name_outputs, family_closure, assemble, Const
+
+
+@family_closure
+def PE_fc(family):
+    Inst, Operand0T, Operand1T, Word, T = ISA_fc(family)
+
+    @assemble(family, locals(), globals())
+    class PE(Peak):
+
+        @name_outputs(out=Word)
+        def __call__(self, inst: Const(Inst), op0: Operand0T, op1: Operand1T) -> Word:
+            o0 = op0
+            if op1[Word].match:
+                # arith op
+                o1 = op1[Word].value
+                if inst.Opcode == Inst.Opcode.A:
+                    return o0 + o1 + inst.offset
+                else:
+                    return o0 - o1 + inst.offset
+            else:
+                # bit op
+                ox = op1[T].value
+                o1 = ox[0]
+                b  = ox[1]
+                if inst.Opcode == Inst.Opcode.A:
+                    res = o0 & o1
+                else:
+                    res = o0 | o1
+                return b.ite(~res, res)
+    return PE
+

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -196,15 +196,6 @@ class IRMapper(SMTMapper):
             ret = is_en and is_unbound and is_const and is_bv
             return ret
 
-        def check_set_unbound_bv(ir_path, arch_path):
-            is_en = archmapper.set_unbound_bv is not None
-            is_unbound = ir_path is Unbound
-            arch_t = arch_input_flat_map[arch_path]
-            is_not_const = not issubclass(arch_t, Const)
-            is_bv = issubclass(arch_t, SBV)
-            ret = is_en and is_unbound and is_not_const and is_bv
-            return ret
-
         constraints = []
         #Build the constraint
         for fi, ibindings in enumerate(input_bindings):
@@ -215,16 +206,8 @@ class IRMapper(SMTMapper):
                 submap = []
                 const_constraints = []
                 for ir_path, arch_path in ibinding:
-                    #if ir_path is Unbound:
-                    #    continue
-                    #ir_var = self.input_varmap[ir_path]
-                    #arch_var = archmapper.input_varmap[arch_path]
                     arch_var = archmapper.input_varmap[arch_path]
-                    if check_set_unbound_bv(ir_path, arch_path):
-                        #replace the arch_value with a constant
-                        ir_var = type(arch_var)(archmapper.set_unbound_bv)
-                        assert 0
-                    elif check_constrain_constant_bv(ir_path, arch_path):
+                    if check_constrain_constant_bv(ir_path, arch_path):
                         width = arch_var.size
                         const_constraint = or_reduce((arch_var == val for val in archmapper.constrain_constant_bv if val < 2**width))
                         const_constraints.append(const_constraint)
@@ -239,7 +222,6 @@ class IRMapper(SMTMapper):
                 for bo, obinding in enumerate(output_bindings):
                     bo_match = (ob_var == 2**bo)
                     conditions = list(form_conditions[fi]) + [bi_match, bo_match] + const_constraints
-                    #conditions = list(form_conditions[fi]) + [bi_match, bo_match]
                     for ir_path, arch_path in obinding:
                         if ir_path is Unbound:
                             continue

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -188,13 +188,11 @@ class IRMapper(SMTMapper):
 
 
         def check_constrain_constant_bv(ir_path, arch_path):
-            is_en = archmapper.constrain_constant_bv is not None
-            is_unbound = ir_path is Unbound
             arch_t = arch_input_flat_map[arch_path]
-            is_const = issubclass(arch_t, Const)
-            is_bv = issubclass(arch_t, SBV)
-            ret = is_en and is_unbound and is_const and is_bv
-            return ret
+            return (archmapper.constrain_constant_bv is not None) and \
+                    (ir_path is Unbound) and \
+                    issubclass(arch_t, Const) and \
+                    issubclass(arch_t, SBV)
 
         constraints = []
         #Build the constraint

--- a/peak/mapper/mapper.py
+++ b/peak/mapper/mapper.py
@@ -1,11 +1,11 @@
 import typing as tp
 import itertools as it
-from peak import family_closure
+from peak import family_closure, Const
 from hwtypes.adt import Product, Tuple
 from hwtypes import SMTBit
 from hwtypes import SMTBitVector as SBV
 from hwtypes import Bit, BitVector
-from hwtypes.modifiers import strip_modifiers, push_modifiers
+from hwtypes.modifiers import strip_modifiers, push_modifiers, wrap_modifier, unwrap_modifier
 from peak.assembler import Assembler, AssembledADT
 from .utils import SMTForms, SimplifyBinding
 from .utils import Unbound, Match
@@ -14,6 +14,7 @@ from .utils import aadt_product_to_dict
 from .utils import solved_to_bv, log2
 from .utils import smt_binding_to_bv_binding
 from .utils import pretty_print_binding
+from hwtypes.adt_meta import GetitemSyntax, AttrSyntax, EnumMeta
 import inspect
 from peak import Peak
 
@@ -96,23 +97,30 @@ class SMTMapper:
 
 
 class ArchMapper(SMTMapper):
-    def __init__(self, arch_fc):
+    def __init__(self, arch_fc, *, constrain_constant_bv=None, set_unbound_bv=None):
         super().__init__(arch_fc)
         if self.num_output_forms > 1:
             raise NotImplementedError("Multiple ir output forms")
+        self.constrain_constant_bv = constrain_constant_bv
+        self.set_unbound_bv = set_unbound_bv
 
     def process_ir_instruction(self, ir_fc):
         return IRMapper(self, ir_fc)
 
 
-def _create_flat_map(adt_t, varmap):
-    flat_map = {}
-    for path in varmap:
-        T = adt_t
-        for field in path:
-            T = T.field_dict[field]
-        flat_map[path] = T
-    return flat_map
+#Return a map from clean path to modified types
+def _create_flat_map(adt_t, path=(), mods=[]):
+    #remove modifiers from this level
+    adt_t, new_mods = unwrap_modifier(adt_t)
+    mods = new_mods + mods
+    flatmap = {}
+    if isinstance(adt_t, (AttrSyntax, GetitemSyntax)) and not isinstance(adt_t, EnumMeta):
+        for n, sub_adt_t in adt_t.field_dict.items():
+            sub_flatmap = _create_flat_map(sub_adt_t, path+(n,), mods)
+            flatmap.update(sub_flatmap)
+    else:
+        flatmap[path] = wrap_modifier(adt_t, mods)
+    return flatmap
 
 
 class IRMapper(SMTMapper):
@@ -132,26 +140,27 @@ class IRMapper(SMTMapper):
         # Create input bindings
         # binding = [input_form_idx][bidx]
         input_bindings = []
-        p_arch_input_adt_t = push_modifiers(archmapper.peak_fc(SMTBit.get_family()).input_t)
-        p_ir_input_adt_t = push_modifiers(self.peak_fc(SMTBit.get_family()).input_t)
-        ir_flat_map = _create_flat_map(p_ir_input_adt_t, ir_input_form.varmap)
-        for af in archmapper.input_forms:
-            arch_flat_map = _create_flat_map(p_arch_input_adt_t, af.varmap)
+        arch_input_flat_map = _create_flat_map(archmapper.peak_fc(SMTBit.get_family()).input_t)
 
-            input_bindings.append(create_bindings(arch_flat_map, ir_flat_map))
+        ir_flat_map = _create_flat_map(self.peak_fc(SMTBit.get_family()).input_t)
+        #Verify all paths are the same
+        assert set(ir_flat_map.keys()) == set(self.input_varmap.keys())
+        for af in archmapper.input_forms:
+            #Verify all paths of form is subset of all paths
+            assert set(arch_input_flat_map.keys()).issuperset(set(af.varmap.keys()))
+            form_arch_input_flat_map = {p:T for p, T in arch_input_flat_map.items() if p in af.varmap}
+            input_bindings.append(create_bindings(form_arch_input_flat_map, ir_flat_map))
         # Check Early out
         self.has_bindings = max(len(bs) for bs in input_bindings) > 0
         if not self.has_bindings:
             return
 
         # Create output bindings
-        p_arch_output_adt_t = push_modifiers(archmapper.peak_fc(SMTBit.get_family()).output_t)
-        p_ir_output_adt_t = push_modifiers(self.peak_fc(SMTBit.get_family()).output_t)
-        arch_flat_map = _create_flat_map(p_arch_output_adt_t, archmapper.output_forms[0][0].varmap)
-        ir_flat_map = _create_flat_map(p_ir_output_adt_t, ir_output_form.varmap)
+        arch_output_flat_map = _create_flat_map(archmapper.peak_fc(SMTBit.get_family()).output_t)
+        ir_flat_map = _create_flat_map(self.peak_fc(SMTBit.get_family()).output_t)
 
         #binding = [bidx]
-        output_bindings = create_bindings(arch_flat_map, ir_flat_map)
+        output_bindings = create_bindings(arch_output_flat_map, ir_flat_map)
 
         # Check Early out
         self.has_bindings = len(output_bindings) > 0
@@ -177,6 +186,25 @@ class IRMapper(SMTMapper):
         max_output_bindings = len(output_bindings)
         ob_var = SBV[max_output_bindings]()
 
+
+        def check_constrain_constant_bv(ir_path, arch_path):
+            is_en = archmapper.constrain_constant_bv is not None
+            is_unbound = ir_path is Unbound
+            arch_t = arch_input_flat_map[arch_path]
+            is_const = issubclass(arch_t, Const)
+            is_bv = issubclass(arch_t, SBV)
+            ret = is_en and is_unbound and is_const and is_bv
+            return ret
+
+        def check_set_unbound_bv(ir_path, arch_path):
+            is_en = archmapper.set_unbound_bv is not None
+            is_unbound = ir_path is Unbound
+            arch_t = arch_input_flat_map[arch_path]
+            is_not_const = not issubclass(arch_t, Const)
+            is_bv = issubclass(arch_t, SBV)
+            ret = is_en and is_unbound and is_not_const and is_bv
+            return ret
+
         constraints = []
         #Build the constraint
         for fi, ibindings in enumerate(input_bindings):
@@ -185,16 +213,33 @@ class IRMapper(SMTMapper):
                 bi_match = (ib_var == 2**bi)
                 #Build substitution map
                 submap = []
+                const_constraints = []
                 for ir_path, arch_path in ibinding:
-                    if ir_path is Unbound:
-                        continue
-                    ir_var = self.input_varmap[ir_path]
+                    #if ir_path is Unbound:
+                    #    continue
+                    #ir_var = self.input_varmap[ir_path]
+                    #arch_var = archmapper.input_varmap[arch_path]
                     arch_var = archmapper.input_varmap[arch_path]
-                    submap.append((arch_var, ir_var))
+                    if check_set_unbound_bv(ir_path, arch_path):
+                        #replace the arch_value with a constant
+                        ir_var = type(arch_var)(archmapper.set_unbound_bv)
+                        assert 0
+                    elif check_constrain_constant_bv(ir_path, arch_path):
+                        width = arch_var.size
+                        const_constraint = or_reduce((arch_var == val for val in archmapper.constrain_constant_bv if val < 2**width))
+                        const_constraints.append(const_constraint)
+                        continue
 
+                    elif ir_path is Unbound:
+                        continue
+                    else:
+                        ir_var = self.input_varmap[ir_path]
+
+                    submap.append((arch_var, ir_var))
                 for bo, obinding in enumerate(output_bindings):
                     bo_match = (ob_var == 2**bo)
-                    conditions = list(form_conditions[fi]) + [bi_match, bo_match]
+                    conditions = list(form_conditions[fi]) + [bi_match, bo_match] + const_constraints
+                    #conditions = list(form_conditions[fi]) + [bi_match, bo_match]
                     for ir_path, arch_path in obinding:
                         if ir_path is Unbound:
                             continue

--- a/peak/mapper/utils.py
+++ b/peak/mapper/utils.py
@@ -11,7 +11,6 @@ from hwtypes.adt_util import rebind_type
 import pysmt.shortcuts as smt
 import typing as tp
 from hwtypes.adt_util import rebind_type
-from hwtypes.modifiers import strip_modifiers, push_modifiers, wrap_modifier, unwrap_modifier
 
 class Match: pass
 class Unbound: pass

--- a/peak/mapper/utils.py
+++ b/peak/mapper/utils.py
@@ -11,6 +11,7 @@ from hwtypes.adt_util import rebind_type
 import pysmt.shortcuts as smt
 import typing as tp
 from hwtypes.adt_util import rebind_type
+from hwtypes.modifiers import strip_modifiers, push_modifiers, wrap_modifier, unwrap_modifier
 
 class Match: pass
 class Unbound: pass
@@ -281,7 +282,6 @@ def create_bindings(
 ):
     arch_by_t = _sort_by_t(arch_flat)
     ir_by_t = _sort_by_t(ir_flat)
-
     #check early out
     if not all((ir_type in arch_by_t) for ir_type in ir_by_t):
         return []
@@ -330,4 +330,3 @@ def pretty_print_binding(binding):
     for ir_path, arch_path in binding:
         print(f"  {_pretty_path(ir_path)} <=> {_pretty_path(arch_path)}")
     print(")")
-

--- a/tests/test_aadt_mapping.py
+++ b/tests/test_aadt_mapping.py
@@ -22,7 +22,6 @@ def test_automapper():
             assert ir_name in expect_not_found
             continue
         assert ir_name in expect_found
-        #pretty_print_binding(solution.ibinding)
         #verify the mapping works
         ir_bv = ir_fc(Bit.get_family())
         for _ in range(num_test_vectors):

--- a/tests/test_aadt_mapping.py
+++ b/tests/test_aadt_mapping.py
@@ -16,8 +16,6 @@ def test_automapper():
     expect_found = ('Add', 'Sub', 'And', 'Nand', 'Or', 'Nor', 'Not', 'Neg')
     expect_not_found = ('Mul', 'Shftr', 'Shftl')
     for ir_name, ir_fc in IR.instructions.items():
-        if ir_name is not "Add":
-            continue
         ir_mapper = arch_mapper.process_ir_instruction(ir_fc)
         solution = ir_mapper.solve('z3')
         if not solution.solved:
@@ -208,31 +206,3 @@ def test_constrain_constant_bv(opts):
     if solution.solved:
         pretty_print_binding(solution.ibinding)
     assert solution.solved == solved
-
-#@pytest.mark.parametrize("opts", (
-#    (None, False),
-#    (4, True)))
-#def test_set_unbound_bv(opts):
-#
-#    arch_fc = PE_fc
-#    arch_bv = arch_fc(Bit.get_family())
-#    arch_mapper = ArchMapper(
-#        arch_fc,
-#        constrain_constant_bv=(0,),
-#        set_unbound_bv=opts[0])
-#
-#    @family_closure
-#    def ir_fc(family):
-#        Data = family.BitVector[8]
-#        @assemble(family, locals(), globals())
-#        class IR(Peak):
-#            @name_outputs(out=Data)
-#            def __call__(self, in0: Data):
-#                return in0 + 4
-#        return IR
-#    ir_mapper = arch_mapper.process_ir_instruction(ir_fc)
-#    assert ir_mapper.has_bindings
-#    solution = ir_mapper.solve('z3')
-#    if solution.solved:
-#        pretty_print_binding(solution.ibinding)
-#    assert solution.solved == opts[1]

--- a/tests/test_aadt_mapping.py
+++ b/tests/test_aadt_mapping.py
@@ -1,11 +1,11 @@
 from hwtypes import Bit, BitVector
 from hwtypes.adt import Enum, Product
-
 from peak.mapper.utils import pretty_print_binding
 from peak.mapper import ArchMapper
 from peak import Const, family_closure, Peak, name_outputs, assemble
-from examples.min_pe.sim import PE_fc
+from examples.sum_pe.sim import PE_fc
 from examples.smallir import gen_SmallIR
+import pytest
 
 num_test_vectors = 16
 def test_automapper():
@@ -16,14 +16,15 @@ def test_automapper():
     expect_found = ('Add', 'Sub', 'And', 'Nand', 'Or', 'Nor', 'Not', 'Neg')
     expect_not_found = ('Mul', 'Shftr', 'Shftl')
     for ir_name, ir_fc in IR.instructions.items():
+        if ir_name is not "Add":
+            continue
         ir_mapper = arch_mapper.process_ir_instruction(ir_fc)
         solution = ir_mapper.solve('z3')
         if not solution.solved:
             assert ir_name in expect_not_found
             continue
         assert ir_name in expect_found
-        pretty_print_binding(solution.ibinding)
-
+        #pretty_print_binding(solution.ibinding)
         #verify the mapping works
         ir_bv = ir_fc(Bit.get_family())
         for _ in range(num_test_vectors):
@@ -180,3 +181,58 @@ def test_early_out_outputs():
     assert not solution.solved
     assert not ir_mapper.has_bindings
 
+
+@pytest.mark.parametrize("opts", (
+    (None, True),
+    ((0, 1, 2), False),
+    ((4, 5), True)))
+def test_constrain_constant_bv(opts):
+    constraint = opts[0]
+    solved = opts[1]
+    arch_fc = PE_fc
+    arch_bv = arch_fc(Bit.get_family())
+    arch_mapper = ArchMapper(arch_fc, constrain_constant_bv=constraint)
+
+    @family_closure
+    def ir_fc(family):
+        Data = family.BitVector[8]
+        @assemble(family, locals(), globals())
+        class IR(Peak):
+            @name_outputs(out=Data)
+            def __call__(self, in0: Data, in1: Data):
+                return in0 + in1 + 4 #inst.offset should be 4
+        return IR
+    ir_mapper = arch_mapper.process_ir_instruction(ir_fc)
+    assert ir_mapper.has_bindings
+    solution = ir_mapper.solve('z3')
+    if solution.solved:
+        pretty_print_binding(solution.ibinding)
+    assert solution.solved == solved
+
+#@pytest.mark.parametrize("opts", (
+#    (None, False),
+#    (4, True)))
+#def test_set_unbound_bv(opts):
+#
+#    arch_fc = PE_fc
+#    arch_bv = arch_fc(Bit.get_family())
+#    arch_mapper = ArchMapper(
+#        arch_fc,
+#        constrain_constant_bv=(0,),
+#        set_unbound_bv=opts[0])
+#
+#    @family_closure
+#    def ir_fc(family):
+#        Data = family.BitVector[8]
+#        @assemble(family, locals(), globals())
+#        class IR(Peak):
+#            @name_outputs(out=Data)
+#            def __call__(self, in0: Data):
+#                return in0 + 4
+#        return IR
+#    ir_mapper = arch_mapper.process_ir_instruction(ir_fc)
+#    assert ir_mapper.has_bindings
+#    solution = ir_mapper.solve('z3')
+#    if solution.solved:
+#        pretty_print_binding(solution.ibinding)
+#    assert solution.solved == opts[1]


### PR DESCRIPTION
@jack-melchert 

This branch allows specifying a set of values that constant bitvector fields can take during the solve.

See test_constrain_constant_bv for an example of the API.

I am also partway done with setting unbound ports to a constant value.