### PR TITLE
Fault poke protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 - cd coreir_release && sudo make install && cd ..
 - pip install -U pip
 install:
+- pip install -e git://github.com/leonardt/fault.git@protocol-value#egg=fault
 - pip install pytest-cov fault mantle
 - pip install python-coveralls
 - pip install -e .


### PR DESCRIPTION
Depends on https://github.com/leonardt/fault/pull/235

Adds support for poking with a magma protocol value.

One option for addressing https://github.com/cdonovick/peak/issues/154

The other option is to have the user explicitly convert it into a Bits representation before poking with fault, which is how the op is poked using `tester.circuit.op = int(asm.assemble(op))`