### PR TITLE
Fix maybe some version/dependency issue?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 import sys
 
 setup(
@@ -9,9 +9,7 @@ setup(
     maintainer='Pat Hanrahan',
     maintainer_email='hanrahan@cs.stanford.edu',
     description='A DSL for Specifying Processors',
-    packages=[
-        "peak",
-    ],
+    packages=find_packages(),
     install_requires=[
         "hwtypes >= 1.3.0",
         "astor",


### PR DESCRIPTION
On my system (Ubuntu 18.04) it seems like the subdirectories (assmbler/ and mapper/) are not installed unless I make the above change. I did not investigate rigorously what was the root cause, but this change seems safe.