### PR TITLE
Unbound ports bug

### DIFF
--- a/examples/sum_pe/sim.py
+++ b/examples/sum_pe/sim.py
@@ -11,7 +11,7 @@ def PE_fc(family):
     class PE(Peak):
 
         @name_outputs(out=isa.Word)
-        def __call__(self, inst: Const(isa.Inst), in0: isa.Word, in1: isa.Word) -> isa.Word:
+        def __call__(self, inst: Const(isa.Inst), in0: isa.Word, in1: isa.Word, in2: isa.Word) -> isa.Word:
             is_bitop = ~inst[isa.ArithOp].match
             if not is_bitop:
                 arithOp = inst[isa.ArithOp].value


### PR DESCRIPTION
Fixes #175 

Unfortunately as a reuslt, the following API changed:
-Removed RewriteRule.build_ir_input
-Removed RewriteRule.build_arch_input
-Added RewriteRule.build_inputs
-RewriteRule.verify() now returns a tuple of paths if a counter example is found

@jack-melchert I suspect this might affect your code.