### PR TITLE
Adds register with update_state semantics, with a hierarchical test

### DIFF
--- a/peak/peak.py
+++ b/peak/peak.py
@@ -28,7 +28,11 @@ class PeakMeta(type):
 
         return cls
 
-class Peak(metaclass=PeakMeta): pass
+class Peak(metaclass=PeakMeta):
+    def update_state(self):
+        for v in self.__dict__.values():
+            if isinstance(v, Peak):
+                v.update_state()
 
 class PeakNotImplementedError(NotImplementedError):
     pass

--- a/peak/register.py
+++ b/peak/register.py
@@ -37,3 +37,34 @@ def gen_register2(family, T, init=0):
     if family.Bit is m.Bit:
         Register = m.circuit.sequential(Register)
     return Register
+
+def gen_Register3(width, init=None):
+
+    if init is None:
+        init = 0
+
+    @family_closure
+    def Register3_fc(family):
+        T = family.BitVector[width]
+
+        class Register3(Peak):
+            def __init__(self):
+                self.value: T = T(init)
+                self.next_value: T = None
+
+            #equivelent to evaluating 'posedge clk'
+            def update_state(self) -> None:
+                self.value = self.next_value
+                self.next_value = None
+
+            def __call__(self, i: T) -> T:
+                self.next_value = i
+                return self.value
+
+            def get(self) -> T:
+                return self.value
+
+            def set(self, v: T) -> None:
+                self.value = v
+        return Register3
+    return Register3_fc

--- a/tests/test_reg3.py
+++ b/tests/test_reg3.py
@@ -1,0 +1,78 @@
+from peak import Peak, family_closure, family
+from peak.register import gen_Register3
+
+@family_closure
+def Mul_fc(family):
+    Data = family.BitVector[16]
+    Reg = gen_Register3(16)(family)
+    @family.assemble(locals(), globals())
+    class Mul(Peak):
+        def __init__(self):
+            self.out_reg: Reg = Reg()
+
+        def __call__(self, a: Data, b: Data) -> Data:
+            return self.out_reg(a*b)
+
+    return Mul
+
+@family_closure
+def Add_fc(family):
+    Data = family.BitVector[16]
+    Reg = gen_Register3(16)(family)
+    @family.assemble(locals(), globals())
+    class Add(Peak):
+        def __init__(self):
+            self.out_reg: Reg = Reg()
+
+        def __call__(self, a: Data, b: Data) -> Data:
+            return self.out_reg(a+b)
+
+    return Add
+
+#Computes a*b +c with latency=2
+@family_closure
+def FMA_fc(family):
+    Data = family.BitVector[16]
+
+    Mul = Mul_fc(family)
+    Add = Add_fc(family)
+    Reg = gen_Register3(16)(family)
+    @family.assemble(locals(), globals())
+    class FMA(Peak):
+        def __init__(self):
+            self.mul: Mul = Mul()
+            self.add: Add = Add()
+            self.c_reg: Reg = Reg()
+
+        def __call__(self, a: Data, b: Data, c: Data) -> Data:
+            mul_out = self.mul(a, b)
+            c_delayed = self.c_reg(c)
+            return self.add(mul_out, c_delayed)
+
+    return FMA
+
+def test_FMA():
+    Data = family.PyFamily().BitVector[16]
+    fma = (FMA_fc.Py)()
+
+    #Assume state has already been updated (or set by test)
+    out0 = fma(a=Data(3), b=Data(5), c=Data(7))
+    assert out0 == Data(0)
+    assert fma.c_reg.get() == Data(0)
+    fma.update_state()
+    assert fma.c_reg.get() == Data(7)
+    out1 = fma(a=Data(0), b=Data(0), c=Data(0))
+    assert out1 == Data(0)
+    assert fma.c_reg.get() == Data(7)
+    fma.update_state()
+    assert fma.c_reg.get() == Data(0)
+    out2 = fma(a=Data(0), b=Data(0), c=Data(0))
+    assert out2 == Data(3*5+7)
+    fma.update_state()
+    fma.c_reg.set(Data(13))
+    out3 = fma(a=Data(0), b=Data(0), c=Data(0))
+    assert out3 == Data(0)
+    assert fma.add.out_reg.get() == Data(0)
+    fma.update_state()
+    assert fma.add.out_reg.get() == Data(13)
+


### PR DESCRIPTION
Using this PR as a new feature review (eg not meant to be merged)

Goal: Add precise verilator-like simulation semantics for peak classes and registers

Under this paradigm (only using Register3 for any state), `__call__(...) ` does not ever update state, but only evaluates the combinational logic defined in Peak. The `Peak.update_state()` method does the state update exactly analogous to toggling the clock in verilator.

To evaluate multiple cycles:
```
peak_obj(...)
peak_obj.update_state()
peak_obv(...)
peak_obj.update_state()
...

```
In addition, there are set() and get() methods for Regsister3 for to dynamically peak and poke the state.

One ultimate goal is to treat state input/outputs similar to peak outputs/inputs (respectively)for the automatic rewrite rule generation cod generation.
