### PR TITLE
Adds a Black Box construct

### DIFF
--- a/examples/fp_pe/__init__.py
+++ b/examples/fp_pe/__init__.py
@@ -1,0 +1,1 @@
+from .sim import *

--- a/examples/fp_pe/sim.py
+++ b/examples/fp_pe/sim.py
@@ -60,7 +60,7 @@ def FPU_fc(family: TypeFamily):
         def __call__(self, op: FPU_op, a: Data, b: Data) -> Data:
             add_out = self.add(a, b)
             mul_out = self.mul(a, b)
-            sqrt_out = self.sqrt(a, b)
+            sqrt_out = self.sqrt(a)
             if op == FPU_op.FPAdd:
                 return add_out
             elif op == FPU_op.FPMul:

--- a/examples/fp_pe/sim.py
+++ b/examples/fp_pe/sim.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+
+from peak import Peak, family_closure, family
+from hwtypes import TypeFamily
+from hwtypes.adt import TaggedUnion, Product, Enum
+from hwtypes import BitVector, Bit
+from peak.family import BlackBox
+
+MagmaFamily = family.MagmaFamily
+
+def Float(frac, exp):
+    width = frac + exp + 1
+    Data = BitVector[width]
+
+    @family_closure
+    def add_fc(family: TypeFamily):
+        @family.assemble(locals(), globals())
+        class add(Peak, BlackBox):
+            def __call__(self, in0: Data, in1: Data) -> Data:
+                ...
+        return add
+
+    @family_closure
+    def mul_fc(family: TypeFamily):
+        @family.assemble(locals(), globals())
+        class mul(Peak, BlackBox):
+            def __call__(self, in0: Data, in1: Data) -> Data:
+                ...
+        return mul
+
+    @family_closure
+    def sqrt_fc(family: TypeFamily):
+        @family.assemble(locals(), globals())
+        class sqrt(Peak, BlackBox):
+            def __call__(self, in_: Data) -> Data:
+                ...
+        return sqrt
+
+    return SimpleNamespace(**locals())
+
+Data = BitVector[16]
+
+class FPU_op(Enum):
+    FPAdd = 0
+    FPMul = 2
+    FPSqrt = 3
+
+BFloat16 = Float(7, 8)
+@family_closure
+def FPU_fc(family: TypeFamily):
+    Add = BFloat16.add_fc(family)
+    Mul = BFloat16.mul_fc(family)
+    Sqrt = BFloat16.sqrt_fc(family)
+    class FPU(Peak):
+        def __init__(self):
+            self.add: Add = Add()
+            self.mul: Mul = Mul()
+            self.sqrt: Sqrt = Sqrt()
+
+        def __call__(self, op: FPU_op, a: Data, b: Data) -> Data:
+            add_out = self.add(a, b)
+            mul_out = self.mul(a, b)
+            sqrt_out = self.sqrt(a, b)
+            if op == FPU_op.FPAdd:
+                return add_out
+            elif op == FPU_op.FPMul:
+                return mul_out
+            else:
+                return sqrt_out
+
+    return FPU
+
+class ALU_op(Enum):
+    Add = 1
+    Sub = 2
+    Or =  3
+    And = 4
+    XOr = 5
+
+@family_closure
+def ALU_fc(family: TypeFamily):
+    class ALU(Peak):
+        def __call__(self, op : ALU_op, a : Data, b : Data) -> Data:
+            if op == ALU_op.Add:
+                res = a + b
+            elif op == ALU_op.Sub:
+                res = a-b
+            elif op == ALU_op.And:
+                res = a & b
+            elif op == ALU_op.Or:
+                res = a | b
+            else: # op == ALU_op.XOr:
+                res = a ^ b
+            return res
+    return ALU
+
+
+class Op(TaggedUnion):
+    alu=ALU_op
+    fpu=FPU_op
+
+class Inst(Product):
+    op = Op
+    imm = Data
+    use_imm = Bit
+
+@family_closure
+def PE_fc(family: TypeFamily):
+    ALU = ALU_fc(family)
+    FPU = FPU_fc(family)
+
+    @family.assemble(locals(), globals())
+    class PE(Peak):
+        def __init__(self):
+            self.FPU: FPU = FPU()
+            self.ALU: ALU = ALU()
+
+        def __call__(self, inst: Inst, a: Data, b: Data) -> Data:
+            if inst.use_imm:
+                b = inst.imm
+            alu_out = self.ALU(inst.op.alu, a, b)
+            fpu_out = self.FPU(inst.op.fpu, a, b)
+            if inst.op.alu.match:
+                ret = alu_out
+            else:
+                ret = fpu_out
+            return ret
+
+    return PE

--- a/peak/black_box.py
+++ b/peak/black_box.py
@@ -1,0 +1,57 @@
+
+class BlackBox:
+
+    @staticmethod
+    def get_black_boxes(pe, path=()):
+
+        #Hack to avoid circular import
+        from .peak import Peak
+
+        assert isinstance(pe, Peak)
+        ret = {}
+        for field, obj in pe.__dict__.items():
+            if isinstance(obj, BlackBox):
+                ret[path + (field,)] = obj
+            if isinstance(obj, Peak):
+                ret = {**ret, **BlackBox.get_black_boxes(obj, path + (field,))}
+        return ret
+
+    @staticmethod
+    def get(obj, path):
+        # Hack to avoid circular import
+        from .peak import Peak
+
+        for field in path:
+            obj = getattr(obj, field, None)
+            if obj is None:
+                raise ValueError(f"{obj} does not have attribute {field}")
+            if not isinstance(obj, Peak):
+                raise ValueError(f"{obj} must be a peak class")
+        return obj
+
+
+    def __init__(self):
+        self._input_vals = None
+        self._output_vals = None
+
+    def __call__(self, *args):
+        if self._output_vals is None:
+            raise ValueError(f"{self}: Need to call _set_outputs before __call__")
+        self._input_vals = args
+        ret = self._output_vals
+        self._output_vals = None
+        return ret
+
+    def _get_inputs(self):
+        if self._input_vals is None:
+            raise ValueError(f"{self}: Need to call __call__ before _get_inputs")
+        ret = self._input_vals
+        self._input_vals = None
+        return ret
+
+    def _set_outputs(self, *args):
+        if len(args)==1:
+            self._output_vals = args[0]
+        else:
+            self._output_vals = args
+

--- a/peak/black_box.py
+++ b/peak/black_box.py
@@ -3,6 +3,7 @@ class BlackBox:
 
     @staticmethod
     def get_black_boxes(pe, path=()):
+        """Gets references to all the black boxes in the hierarchical circuit"""
 
         #Hack to avoid circular import
         from .peak import Peak
@@ -16,8 +17,10 @@ class BlackBox:
                 ret = {**ret, **BlackBox.get_black_boxes(obj, path + (field,))}
         return ret
 
+    #Returns
     @staticmethod
-    def get(obj, path):
+    def get_black_box(obj, path):
+        """Gets a specific black box given a path"""
         # Hack to avoid circular import
         from .peak import Peak
 
@@ -38,16 +41,12 @@ class BlackBox:
         if self._output_vals is None:
             raise ValueError(f"{self}: Need to call _set_outputs before __call__")
         self._input_vals = args
-        ret = self._output_vals
-        self._output_vals = None
-        return ret
+        return self._output_vals
 
     def _get_inputs(self):
         if self._input_vals is None:
             raise ValueError(f"{self}: Need to call __call__ before _get_inputs")
-        ret = self._input_vals
-        self._input_vals = None
-        return ret
+        return self._input_vals
 
     def _set_outputs(self, *args):
         if len(args)==1:

--- a/peak/family.py
+++ b/peak/family.py
@@ -10,6 +10,7 @@ import magma as m
 
 from .assembler import Assembler
 from .assembler import AssembledADT, MagmaADT
+from .black_box import BlackBox
 
 __ALL__ = ['PyFamily', 'SMTFamily', 'MagmaFamily']
 
@@ -191,32 +192,6 @@ class PyFamily(_RegFamily):
     def get_constructor(self, adt_t):
         return adt_t
 
-
-class BlackBox:
-    def __init__(self):
-        self._input_vals = None
-        self._output_vals = None
-
-    def __call__(self, *args):
-        if self._output_vals is None:
-            raise ValueError(f"{self}: Need to call _set_outputs before __call__")
-        self._input_vals = args
-        ret = self._output_vals
-        self._output_vals = None
-        return ret
-
-    def _get_inputs(self):
-        if self._input_vals is None:
-            raise ValueError(f"{self}: Need to call __call__ before _get_inputs")
-        ret = self._input_vals
-        self._input_vals = None
-        return ret
-
-    def _set_outputs(self, *args):
-        if len(args)==1:
-            self._output_vals = args[0]
-        else:
-            self._output_vals = args
 
 
 # Strategically put _AsmFamily first so eq dispatches to it

--- a/peak/family.py
+++ b/peak/family.py
@@ -198,10 +198,12 @@ class BlackBox:
         self._output_vals = None
 
     def __call__(self, *args):
-        if self._set_outputs is None:
+        if self._output_vals is None:
             raise ValueError(f"{self}: Need to call _set_outputs before __call__")
         self._input_vals = args
-        return self._output_vals
+        ret = self._output_vals
+        self._output_vals = None
+        return ret
 
     def _get_inputs(self):
         if self._input_vals is None:

--- a/tests/test_black_box.py
+++ b/tests/test_black_box.py
@@ -1,0 +1,83 @@
+#import pytest
+
+from hwtypes import Bit, BitVector
+
+from peak import Const, family_closure, Peak, name_outputs
+from peak.family import BlackBox
+from peak.family import SMTFamily
+#from peak.mapper import ArchMapper, RewriteRule
+
+
+def test_black_box_rr():
+    @family_closure
+    def BB_fc(family):
+        Data = BitVector[8]
+
+        @family.assemble(locals(), globals())
+        class BB(Peak, BlackBox):
+            def __call__(self, x: Data) -> Data:
+                ...
+
+        return BB
+
+    @family_closure
+    def PE_fc(family):
+        Data = BitVector[8]
+        BB = BB_fc(family)
+
+        @family.assemble(locals(), globals())
+        class PE(Peak):
+            def __init__(self):
+                self.BB1: BB = BB()
+                self.BB2: BB = BB()
+                self.BB3: BB = BB()
+
+            def __call__(self, instr: Const(BitVector[2]), in_: Data) -> Data:
+                b1 = self.BB1(in_)
+                b2 = self.BB2(~in_)
+                b3 = ~(self.BB3(in_))
+                if instr==0:
+                    return in_ + 5
+                elif instr==1:
+                    return b1;
+                elif instr==2:
+                    return b2
+                else:
+                    return b3
+        return PE
+
+    SBV = SMTFamily().BitVector
+    b = [SBV[8](name=f"b{i}") for i in range(4)]
+    x = SBV[8](name='x')
+    pe_smt = PE_fc(SMTFamily())()
+    pe_smt.BB1._set_outputs(b[1])
+    pe_smt.BB2._set_outputs(b[2])
+    pe_smt.BB3._set_outputs(b[3])
+
+    def check(v):
+        assert v.value.is_constant()
+        assert v.value.constant_value()
+
+    def check_BB_inputs():
+        b1_in = pe_smt.BB1._get_inputs()[0]
+        b2_in = pe_smt.BB2._get_inputs()[0]
+        b3_in = pe_smt.BB3._get_inputs()[0]
+        check(b1_in == x)
+        check(b2_in == ~x)
+        check(b3_in == x)
+
+    for i, out in enumerate((
+        x+5,
+        b[1],
+        b[2],
+        ~b[3]
+    )):
+        v = pe_smt(SBV[2](i), x)
+        check(v==out)
+        check_BB_inputs()
+
+
+
+
+
+

--- a/tests/test_black_box.py
+++ b/tests/test_black_box.py
@@ -4,52 +4,85 @@ from hwtypes import Bit, BitVector
 
 from peak import Const, family_closure, Peak, name_outputs
 from peak.family import BlackBox
-from peak.family import SMTFamily
+from peak.family import SMTFamily, PyFamily
 #from peak.mapper import ArchMapper, RewriteRule
 
+@family_closure
+def BB_fc(family):
+    Data = BitVector[8]
 
-def test_black_box_rr():
-    @family_closure
-    def BB_fc(family):
-        Data = BitVector[8]
+    @family.assemble(locals(), globals())
+    class BB(Peak, BlackBox):
+        def __call__(self, x: Data) -> Data:
+            ...
 
-        @family.assemble(locals(), globals())
-        class BB(Peak, BlackBox):
-            def __call__(self, x: Data) -> Data:
-                ...
+    return BB
 
-        return BB
 
-    @family_closure
-    def PE_fc(family):
-        Data = BitVector[8]
-        BB = BB_fc(family)
+@family_closure
+def PE_fc(family):
+    Data = BitVector[8]
+    BB = BB_fc(family)
 
-        @family.assemble(locals(), globals())
-        class PE(Peak):
-            def __init__(self):
-                self.BB1: BB = BB()
-                self.BB2: BB = BB()
-                self.BB3: BB = BB()
+    @family.assemble(locals(), globals())
+    class PE(Peak):
+        def __init__(self):
+            self.BB1: BB = BB()
+            self.BB2: BB = BB()
+            self.BB3: BB = BB()
 
-            def __call__(self, instr: Const(BitVector[2]), in_: Data) -> Data:
-                b1 = self.BB1(in_)
-                b2 = self.BB2(~in_)
-                b3 = ~(self.BB3(in_))
-                if instr==0:
-                    return in_ + 5
-                elif instr==1:
-                    return b1;
-                elif instr==2:
-                    return b2
-                else:
-                    return b3
-        return PE
+        def __call__(self, instr: Const(BitVector[2]), in_: Data) -> Data:
+            b1 = self.BB1(in_)
+            b2 = self.BB2(~in_)
+            b3 = ~(self.BB3(in_))
+            if instr == 0:
+                return in_ + 5
+            elif instr == 1:
+                return b1;
+            elif instr == 2:
+                return b2
+            else:
+                return b3
+
+    return PE
+
+def test_black_box_py():
+
+    BV = PyFamily().BitVector
+    b = [BV[8](i) for i in range(4)]
+    x = BV[8](13)
+    pe_py = PE_fc.Py()
+    pe_py.BB1._set_outputs(b[1])
+    pe_py.BB2._set_outputs(b[2])
+    pe_py.BB3._set_outputs(b[3])
+
+    def check(v):
+        assert v
+
+    def check_BB_inputs():
+        b1_in = pe_py.BB1._get_inputs()[0]
+        b2_in = pe_py.BB2._get_inputs()[0]
+        b3_in = pe_py.BB3._get_inputs()[0]
+        check(b1_in == x)
+        check(b2_in == ~x)
+        check(b3_in == x)
+
+    for i, out in enumerate((
+        x+5,
+        b[1],
+        b[2],
+        ~b[3]
+    )):
+        v = pe_py(BV[2](i), x)
+        check(v==out)
+        check_BB_inputs()
+
+def test_black_box_smt():
 
     SBV = SMTFamily().BitVector
     b = [SBV[8](name=f"b{i}") for i in range(4)]
     x = SBV[8](name='x')
-    pe_smt = PE_fc(SMTFamily())()
+    pe_smt = PE_fc.SMT()
     pe_smt.BB1._set_outputs(b[1])
     pe_smt.BB2._set_outputs(b[2])
     pe_smt.BB3._set_outputs(b[3])

--- a/tests/test_black_box.py
+++ b/tests/test_black_box.py
@@ -52,9 +52,7 @@ def test_black_box_py():
     b = [BV[8](i) for i in range(4)]
     x = BV[8](13)
     pe_py = PE_fc.Py()
-    pe_py.BB1._set_outputs(b[1])
-    pe_py.BB2._set_outputs(b[2])
-    pe_py.BB3._set_outputs(b[3])
+
 
     def check(v):
         assert v
@@ -73,6 +71,9 @@ def test_black_box_py():
         b[2],
         ~b[3]
     )):
+        pe_py.BB1._set_outputs(b[1])
+        pe_py.BB2._set_outputs(b[2])
+        pe_py.BB3._set_outputs(b[3])
         v = pe_py(BV[2](i), x)
         check(v==out)
         check_BB_inputs()
@@ -83,9 +84,7 @@ def test_black_box_smt():
     b = [SBV[8](name=f"b{i}") for i in range(4)]
     x = SBV[8](name='x')
     pe_smt = PE_fc.SMT()
-    pe_smt.BB1._set_outputs(b[1])
-    pe_smt.BB2._set_outputs(b[2])
-    pe_smt.BB3._set_outputs(b[3])
+
 
     def check(v):
         assert v.value.is_constant()
@@ -105,6 +104,9 @@ def test_black_box_smt():
         b[2],
         ~b[3]
     )):
+        pe_smt.BB1._set_outputs(b[1])
+        pe_smt.BB2._set_outputs(b[2])
+        pe_smt.BB3._set_outputs(b[3])
         v = pe_smt(SBV[2](i), x)
         check(v==out)
         check_BB_inputs()

--- a/tests/test_black_box_rr.py
+++ b/tests/test_black_box_rr.py
@@ -1,8 +1,6 @@
 import examples.fp_pe as fp
 from hwtypes import SMTBitVector as SBV, SMTBit as SBit
 from peak.family import SMTFamily, BlackBox
-from peak import Peak
-
 
 def test_fp_pe_bb():
     PE = fp.PE_fc.Py
@@ -15,16 +13,17 @@ def test_fp_pe_bb():
     ):
         assert path in paths_to_bbs
         bb_inst = paths_to_bbs[path]
-        assert bb_inst is BlackBox.get(pe, path)
+        assert bb_inst is BlackBox.get_black_box(pe, path)
         assert isinstance(bb_inst, BlackBox)
 
 
 def test_fp_pe_py():
 
     PE = fp.PE_fc.Py
-    PE.get_black_boxes()
     pe = PE()
-    Data = fp.Data
+    paths_to_bbs = BlackBox.get_black_boxes(pe)
+    for bb in paths_to_bbs.values():
+        bb._set_outputs(fp.Data(0))
     inst = fp.Inst(
         op=fp.Op(alu=fp.ALU_op.Add),
         imm=fp.Data(10),
@@ -32,6 +31,9 @@ def test_fp_pe_py():
     )
     val = pe(inst, fp.Data(5), fp.Data(2))
     assert val == fp.Data(15)
+    assert paths_to_bbs[("FPU", "add")]._get_inputs() == (fp.Data(5), fp.Data(10))
+    assert paths_to_bbs[("FPU", "mul")]._get_inputs() == (fp.Data(5), fp.Data(10))
+    assert paths_to_bbs[("FPU", "sqrt")]._get_inputs() == (fp.Data(5),)
 
 def test_fp_pe_smt():
     pe = fp.PE_fc.SMT()
@@ -43,11 +45,9 @@ def test_fp_pe_smt():
         imm=SBV[16](10),
         use_imm=SBit(name='ui')
     )
+    paths_to_bbs = BlackBox.get_black_boxes(pe)
+    for bb in paths_to_bbs.values():
+        bb._set_outputs(SBV[16]())
     val = pe(inst, SBV[16](name='a'), SBV[16](2))
-    iwidth = AInst._assembler_.width
-    inst = AInst(SBV[iwidth](name='i'))
-    val = pe(inst, SBV[16](name='a'), SBV[16](name='b'))
-
-
-
-
+    for bb in paths_to_bbs.values():
+        bb_inputs = bb._get_inputs()

--- a/tests/test_black_box_rr.py
+++ b/tests/test_black_box_rr.py
@@ -1,10 +1,29 @@
 import examples.fp_pe as fp
 from hwtypes import SMTBitVector as SBV, SMTBit as SBit
-from peak.family import SMTFamily
+from peak.family import SMTFamily, BlackBox
+from peak import Peak
+
+
+def test_fp_pe_bb():
+    PE = fp.PE_fc.Py
+    pe = PE()
+    paths_to_bbs = BlackBox.get_black_boxes(pe)
+    for path in (
+        ("FPU", "add"),
+        ("FPU", "mul"),
+        ("FPU", "sqrt"),
+    ):
+        assert path in paths_to_bbs
+        bb_inst = paths_to_bbs[path]
+        assert bb_inst is BlackBox.get(pe, path)
+        assert isinstance(bb_inst, BlackBox)
+
 
 def test_fp_pe_py():
 
-    pe = fp.PE_fc.Py()
+    PE = fp.PE_fc.Py
+    PE.get_black_boxes()
+    pe = PE()
     Data = fp.Data
     inst = fp.Inst(
         op=fp.Op(alu=fp.ALU_op.Add),
@@ -28,4 +47,7 @@ def test_fp_pe_smt():
     iwidth = AInst._assembler_.width
     inst = AInst(SBV[iwidth](name='i'))
     val = pe(inst, SBV[16](name='a'), SBV[16](name='b'))
+
+
+
 

--- a/tests/test_black_box_rr.py
+++ b/tests/test_black_box_rr.py
@@ -1,0 +1,31 @@
+import examples.fp_pe as fp
+from hwtypes import SMTBitVector as SBV, SMTBit as SBit
+from peak.family import SMTFamily
+
+def test_fp_pe_py():
+
+    pe = fp.PE_fc.Py()
+    Data = fp.Data
+    inst = fp.Inst(
+        op=fp.Op(alu=fp.ALU_op.Add),
+        imm=fp.Data(10),
+        use_imm=fp.Bit(1)
+    )
+    val = pe(inst, fp.Data(5), fp.Data(2))
+    assert val == fp.Data(15)
+
+def test_fp_pe_smt():
+    pe = fp.PE_fc.SMT()
+    AInst = SMTFamily().get_adt_t(fp.Inst)
+    inst = AInst.from_fields(
+        op=AInst.op(
+            fpu=AInst.op.fpu(fp.FPU_op.FPAdd)
+        ),
+        imm=SBV[16](10),
+        use_imm=SBit(name='ui')
+    )
+    val = pe(inst, SBV[16](name='a'), SBV[16](2))
+    iwidth = AInst._assembler_.width
+    inst = AInst(SBV[iwidth](name='i'))
+    val = pe(inst, SBV[16](name='a'), SBV[16](name='b'))
+


### PR DESCRIPTION
Creates a black box class which Peak classes can inherit from.
BlackBox allows getting the inputs to __call__ and setting the outputs of __call__ in preperation for the BlackBox rewrite rule generation.

Creates a largeish PE that contains a level of hierarchy and floating point operations specified as black boxes.
tests basic black operations

